### PR TITLE
fix get-all-shortcuts error

### DIFF
--- a/desktop-app/app/shortcut-manager/main-shortcut-manager.js
+++ b/desktop-app/app/shortcut-manager/main-shortcut-manager.js
@@ -48,6 +48,8 @@ export function initMainShortcutManager() {
         const ok = unregisterShortcut(id);
         event.reply(UNREGISTER_REPLY_CHANNEL, { ok, id });
     });
+  
+    ipcMain.removeHandler(GET_ALL_CHANNEL);
 
     ipcMain.handle(GET_ALL_CHANNEL, () => {
         return getAllShortcuts();


### PR DESCRIPTION
fix get-all-shortcuts by adding removeHandler method, the solution provided by @jjavierdguezas .

For more details, see https://github.com/manojVivek/responsively-app/issues/184

fix https://github.com/manojVivek/responsively-app/issues/184