### PR TITLE
Adds a user preference option to remove fixed positioned elements during full page screenshots

### DIFF
--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -35,7 +35,7 @@ export default function UserPreference({
                 onChange={e =>
                   onChange('disableSSLValidation', e.target.checked)
                 }
-                name="Diable SSL Validation"
+                name="Disable SSL Validation"
                 color="primary"
               />
             }

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -86,23 +86,25 @@ export default function UserPreference({
             }
           />
         </div>
-      </div>
-      <div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={userPreferences.removeFixedElements || false}
-              onChange={e => onChange('removeFixedElements', e.target.checked)}
-              name="Remove fixed position elements from full screenshot"
-              color="primary"
-            />
-          }
-          label={
-            <span className={cx(styles.preferenceName)}>
-              Remove fixed position elements from full screenshot
-            </span>
-          }
-        />
+        <div>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={userPreferences.removeFixedPositionedElements || false}
+                onChange={e =>
+                  onChange('removeFixedPositionedElements', e.target.checked)
+                }
+                name="Remove fixed position elements from full page screenshot"
+                color="primary"
+              />
+            }
+            label={
+              <span className={cx(styles.preferenceName)}>
+                Remove fixed position elements from full page screenshot
+              </span>
+            }
+          />
+        </div>
       </div>
       <div className={cx(commonStyles.sidebarContentSectionContainer)}>
         <div>

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -87,6 +87,23 @@ export default function UserPreference({
           />
         </div>
       </div>
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={userPreferences.removeFixedElements || false}
+              onChange={e => onChange('removeFixedElements', e.target.checked)}
+              name="Remove fixed position elements from full screenshot"
+              color="primary"
+            />
+          }
+          label={
+            <span className={cx(styles.preferenceName)}>
+              Remove fixed position elements from full screenshot
+            </span>
+          }
+        />
+      </div>
       <div className={cx(commonStyles.sidebarContentSectionContainer)}>
         <div>
           <FormControlLabel

--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -368,6 +368,8 @@ class WebView extends Component {
       createSeparateDir: now != null,
       fullScreen,
       now,
+      removeFixedPositionedElements: this.props.browser.userPreferences
+        .removeFixedPositionedElements,
     });
     this.setState({screenshotInProgress: false});
   };

--- a/desktop-app/app/components/WebView/screenshotUtil.js
+++ b/desktop-app/app/components/WebView/screenshotUtil.js
@@ -22,6 +22,7 @@ const captureScreenshot = async ({
   createSeparateDir,
   now,
   fullScreen = false,
+  removeFixedPositionedElements,
 }: {
   address: string,
   device: Device,
@@ -29,6 +30,7 @@ const captureScreenshot = async ({
   createSeparateDir: boolean,
   now?: Date,
   fullScreen: boolean,
+  removeFixedPositionedElements: boolean,
 }) => {
   const worker = new Worker('./imageWorker.js');
   const promiseWorker = new PromiseWorker(worker);
@@ -126,10 +128,16 @@ class WebViewUtils {
       }
     `);
 
-    await this.webView.executeJavaScript(`
-      document.body.classList.add('responsivelyApp__ScreenshotInProgress');
-      responsivelyApp.hideFixedPositionElementsForScreenshot();
-    `);
+    // await this.webView.executeJavaScript(`
+
+    // `);
+
+    if (removeFixedPositionedElements) {
+      await this.webView.executeJavaScript(`
+        document.body.classList.add('responsivelyApp__ScreenshotInProgress');
+        responsivelyApp.hideFixedPositionElementsForScreenshot();
+      `);
+    }
 
     // wait a little for the 'hide' effect to take place.
     await _delay(200);

--- a/desktop-app/app/components/WebView/screenshotUtil.js
+++ b/desktop-app/app/components/WebView/screenshotUtil.js
@@ -42,7 +42,9 @@ const captureScreenshot = async ({
     {autoClose: false}
   );
   const webViewUtils = new WebViewUtils(webView);
-  const insertedCSSKey = await webViewUtils.hideScrollbarAndFixedPositionedElements();
+  const insertedCSSKey = await webViewUtils.hideScrollbarAndFixedPositionedElements(
+    removeFixedPositionedElements
+  );
 
   const images = fullScreen
     ? await webViewUtils.getFullScreenImages(promiseWorker)
@@ -117,7 +119,9 @@ class WebViewUtils {
     await _delay(200);
   }
 
-  async hideScrollbarAndFixedPositionedElements(): Promise<string> {
+  async hideScrollbarAndFixedPositionedElements(
+    removeFixedPositionedElements: boolean
+  ): Promise<string> {
     const key = await this.webView.insertCSS(`
       .responsivelyApp__ScreenshotInProgress::-webkit-scrollbar {
         display: none;
@@ -127,10 +131,6 @@ class WebViewUtils {
         display: none !important;
       }
     `);
-
-    // await this.webView.executeJavaScript(`
-
-    // `);
 
     if (removeFixedPositionedElements) {
       await this.webView.executeJavaScript(`

--- a/desktop-app/app/reducers/browser.js
+++ b/desktop-app/app/reducers/browser.js
@@ -119,6 +119,7 @@ type UserPreferenceType = {
   devToolsOpenMode: DevToolsOpenModeType,
   deviceOutlineStyle: string,
   zoomLevel: number,
+  removeFixedPositionedElements: boolean,
 };
 
 type FilterFieldType = FILTER_FIELDS.OS | FILTER_FIELDS.DEVICE_TYPE;


### PR DESCRIPTION
## Description:
- Previously, full page screenshots would hide `position: fixed` elements to avoid having the elements repeated. Now users can choose whether to do this on know through the user preferences.

## Changes I Made:
- Added checkbox in user preferences for removing fixed positioned elements in full page screenshots.
- Added state for the new user preference to browser reducer.
- Added logic to WebView component and screenshotUtil.js to only remove fixed positioned elements when option is checked.
