### PR TITLE
Feature/generate checksums

### DIFF
--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -63,6 +63,7 @@
   "main": "./app/main.prod.js",
   "build": {
     "afterSign": "scripts/notarize.js",
+    "afterAllArtifactBuild": "scripts/extraPublishFiles.js",
     "productName": "ResponsivelyApp",
     "appId": "app.responsively",
     "files": [

--- a/desktop-app/scripts/extraPublishFiles.js
+++ b/desktop-app/scripts/extraPublishFiles.js
@@ -1,13 +1,28 @@
 const {generateChecksums} = require('./generate-checksums');
+const {version, build, productName} = require('../package.json');
+const path = require('path');
+const fs = require('fs');
 
-exports.default = function() {
-  return generateChecksums()
-    .then(files => {
-      // add *.zip file
-      return files;
-    })
-    .catch(e => {
-      console.log('Something went wrong generating checksum files');
-      return [];
-    });
+const RELATIVE_FOLDER_PATH = '../release';
+
+const getZipFile = () => {
+  const product = (build || {}).productName || productName;
+  const zipName = `${product}-${version}.zip`;
+  const zipPath = path.resolve(__dirname, RELATIVE_FOLDER_PATH, zipName);
+
+  if (fs.existsSync(zipPath)) {
+    console.log(`\nIncluded '${zipName}' in publish files`);
+    return zipPath;
+  }
+  throw new Error(`Expected zip file '${zipPath}' not found`);
 };
+
+const getExtraPublishFiles = () =>
+  generateChecksums().then(files => {
+    const zipFile = getZipFile();
+    const all = [zipFile, ...files];
+    console.log(`\nExtra Files Included:\n${all.join('\n')}`);
+    return all;
+  });
+
+exports.default = getExtraPublishFiles;

--- a/desktop-app/scripts/extraPublishFiles.js
+++ b/desktop-app/scripts/extraPublishFiles.js
@@ -1,0 +1,13 @@
+const {generateChecksums} = require('./generate-checksums');
+
+exports.default = function() {
+  return generateChecksums()
+    .then(files => {
+      // add *.zip file
+      return files;
+    })
+    .catch(e => {
+      console.log('Something went wrong generating checksum files');
+      return [];
+    });
+};

--- a/desktop-app/scripts/generate-checksums.js
+++ b/desktop-app/scripts/generate-checksums.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+
+function hashFile(file, algorithm = 'sha512', encoding = 'base64', options) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash(algorithm);
+    hash.on('error', reject).setEncoding(encoding);
+    fs.createReadStream(
+      file,
+      Object.assign({}, options, {
+        highWaterMark: 1024 * 1024,
+        /* better to use more memory but hash faster */
+      })
+    )
+      .on('error', reject)
+      .on('end', () => {
+        hash.end();
+        resolve(hash.read());
+      })
+      .pipe(hash, {
+        end: false,
+      });
+  });
+}
+
+const RELATIVE_FOLDER_PATH = '../release';
+const CHECKSUM_SUFFIX = '.checksum.sha512';
+const SKIP_SUFFIX_LIST = [CHECKSUM_SUFFIX, '.yml', '.yaml', '.txt'];
+
+const generateChecksums = async () => {
+  const result = [];
+  const installerPath = path.resolve(__dirname, RELATIVE_FOLDER_PATH);
+  const files = await fs.promises.readdir(installerPath);
+  console.log("Generating checksum files for files in: '%s'", installerPath);
+
+  for (const file of files) {
+    if (SKIP_SUFFIX_LIST.some(s => file.endsWith(s))) continue;
+
+    const filePath = path.join(installerPath, file);
+    const stat = await fs.promises.stat(filePath);
+
+    if (stat.isFile()) {
+      const checksumFile = `${file}${CHECKSUM_SUFFIX}`;
+      const checksumFilePath = path.join(installerPath, checksumFile);
+      const checksum = await hashFile(filePath);
+      await fs.promises.writeFile(checksumFilePath, checksum);
+      console.log("'%s' -> '%s'", checksum, checksumFile);
+      result.push(checksumFilePath);
+    }
+  }
+  return result;
+};
+
+module.exports = {generateChecksums};

--- a/desktop-app/scripts/generate-checksums.js
+++ b/desktop-app/scripts/generate-checksums.js
@@ -2,12 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 
-function hashFile(
-  file,
-  algorithm = 'sha512',
-  encoding = 'base64',
-  options = {}
-) {
+function hashFile(file, algorithm = 'sha512', encoding = 'hex', options = {}) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash(algorithm);
     hash.on('error', reject).setEncoding(encoding);

--- a/desktop-app/scripts/generate-checksums.js
+++ b/desktop-app/scripts/generate-checksums.js
@@ -2,7 +2,12 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 
-function hashFile(file, algorithm = 'sha512', encoding = 'base64', options) {
+function hashFile(
+  file,
+  algorithm = 'sha512',
+  encoding = 'base64',
+  options = {}
+) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash(algorithm);
     hash.on('error', reject).setEncoding(encoding);
@@ -32,7 +37,7 @@ const generateChecksums = async () => {
   const result = [];
   const installerPath = path.resolve(__dirname, RELATIVE_FOLDER_PATH);
   const files = await fs.promises.readdir(installerPath);
-  console.log("Generating checksum files for files in: '%s'", installerPath);
+  console.log("\nGenerating checksum files for files in: '%s'", installerPath);
 
   for (const file of files) {
     if (SKIP_SUFFIX_LIST.some(s => file.endsWith(s))) continue;


### PR DESCRIPTION
Based on this [electron-builder documentation](https://www.electron.build/configuration/configuration#afterallartifactbuild)
The script to generate checksums was copied from: https://github.com/electron-userland/electron-builder/issues/3913#issuecomment-504698845
Also this include the [zip file](https://github.com/responsively-org/responsively-app/issues/95#issuecomment-683293784) (assuming that it is generated in `release` folder and its name is always `PRODUCT_NAME-VERSION.zip`

Obviously I do not tested it with a `publish` command but it goes well with `yarn package-win`

resolves #95 