### PR TITLE
Fixed persistent hover effect

### DIFF
--- a/desktop-app/app/components/ToggleTouch/index.js
+++ b/desktop-app/app/components/ToggleTouch/index.js
@@ -51,12 +51,15 @@ export default function ToggleTouch({iconProps}) {
       className={cx(commonClasses.icon, {
         [commonClasses.iconSelected]: isTouchMode,
       })}
+      onPointerEnter={() => {
+        setHover(true);
+        setTooltip(true);
+      }}
       onPointerLeave={() => {
         setHover(false);
         setTooltip(false);
       }}
       onPointerMove={() => {
-        setTooltip(true);
         if (!hasPendingState) {
           return;
         }

--- a/desktop-app/app/components/ToggleTouch/index.js
+++ b/desktop-app/app/components/ToggleTouch/index.js
@@ -26,7 +26,7 @@ export default function ToggleTouch({iconProps}) {
 
   const handleToggleTouch = () => {
     setIsTouchMode(!isTouchMode);
-    setTooltip(isTouchMode);
+    setTooltip(!isTouchMode);
     if (isHover) {
       return setPendingState(true);
     }
@@ -51,13 +51,9 @@ export default function ToggleTouch({iconProps}) {
       className={cx(commonClasses.icon, {
         [commonClasses.iconSelected]: isTouchMode,
       })}
-      onPointerEnter={() => {
-        setHover(true);
-        setTooltip(true);
-      }}
+      onMouseEnter={() => setHover(true)}
       onPointerLeave={() => {
         setHover(false);
-        setTooltip(false);
       }}
       onPointerMove={() => {
         if (!hasPendingState) {
@@ -66,11 +62,8 @@ export default function ToggleTouch({iconProps}) {
         syncState(isTouchMode);
         setPendingState(false);
       }}
-      onPointerUp={() => {
-        setTooltip(false);
-      }}
     >
-      <Tooltip title="Toggle Touch Mode" open={hasTooltip}>
+      <Tooltip title={hasTooltip ? '' : 'Toggle Touch Mode'}>
         <div onClick={handleToggleTouch}>
           <ToggleTouchIcon {...iconProps} />
         </div>

--- a/desktop-app/app/components/ToggleTouch/index.js
+++ b/desktop-app/app/components/ToggleTouch/index.js
@@ -9,6 +9,7 @@ export default function ToggleTouch({iconProps}) {
   const [isTouchMode, setIsTouchMode] = useState(false);
   const [isHover, setHover] = useState(false);
   const [hasPendingState, setPendingState] = useState(false);
+  const [hasTooltip, setTooltip] = useState(false);
   const commonClasses = useCommonStyles();
 
   useEffect(() => {
@@ -25,6 +26,7 @@ export default function ToggleTouch({iconProps}) {
 
   const handleToggleTouch = () => {
     setIsTouchMode(!isTouchMode);
+    setTooltip(!isTouchMode);
     if (isHover) {
       return setPendingState(true);
     }
@@ -61,7 +63,7 @@ export default function ToggleTouch({iconProps}) {
         setPendingState(false);
       }}
     >
-      <Tooltip title="Toggle Touch Mode">
+      <Tooltip title={hasTooltip ? '' : 'Toggle Touch Mode'}>
         <div onClick={handleToggleTouch}>
           <ToggleTouchIcon {...iconProps} />
         </div>

--- a/desktop-app/app/components/ToggleTouch/index.js
+++ b/desktop-app/app/components/ToggleTouch/index.js
@@ -50,8 +50,10 @@ export default function ToggleTouch({iconProps}) {
         [commonClasses.iconSelected]: isTouchMode,
       })}
       onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => {
+      onPointerLeave={() => {
         setHover(false);
+      }}
+      onPointerMove={() => {
         if (!hasPendingState) {
           return;
         }

--- a/desktop-app/app/components/ToggleTouch/index.js
+++ b/desktop-app/app/components/ToggleTouch/index.js
@@ -26,7 +26,7 @@ export default function ToggleTouch({iconProps}) {
 
   const handleToggleTouch = () => {
     setIsTouchMode(!isTouchMode);
-    setTooltip(!isTouchMode);
+    setTooltip(isTouchMode);
     if (isHover) {
       return setPendingState(true);
     }
@@ -51,19 +51,23 @@ export default function ToggleTouch({iconProps}) {
       className={cx(commonClasses.icon, {
         [commonClasses.iconSelected]: isTouchMode,
       })}
-      onMouseEnter={() => setHover(true)}
       onPointerLeave={() => {
         setHover(false);
+        setTooltip(false);
       }}
       onPointerMove={() => {
+        setTooltip(true);
         if (!hasPendingState) {
           return;
         }
         syncState(isTouchMode);
         setPendingState(false);
       }}
+      onPointerUp={() => {
+        setTooltip(false);
+      }}
     >
-      <Tooltip title={hasTooltip ? '' : 'Toggle Touch Mode'}>
+      <Tooltip title="Toggle Touch Mode" open={hasTooltip}>
         <div onClick={handleToggleTouch}>
           <ToggleTouchIcon {...iconProps} />
         </div>


### PR DESCRIPTION
This is a fix to issue https://github.com/responsively-org/responsively-app/issues/388

The cause of the bug was that the state of the pointer (mouse/touch) was updated as the pointer left the button. With this fix, the state is updated on mouse movement within the button, giving it a more responsive feel.