### PR TITLE
Bug/fix broken error boundary for light theme

### DIFF
--- a/desktop-app/app/components/ErrorBoundary/index.js
+++ b/desktop-app/app/components/ErrorBoundary/index.js
@@ -69,6 +69,7 @@ class ErrorBoundary extends React.Component {
 
 const styles = theme => ({
   errorBoundaryContainer: {
+    background: theme.palette.background.default,
     overflowY: 'auto',
     display: 'flex',
     flexDirection: 'column',

--- a/desktop-app/app/components/useCreateTheme.js
+++ b/desktop-app/app/components/useCreateTheme.js
@@ -72,7 +72,7 @@ const darkTheme = {
       l20: '#aeaeae',
     },
     border: {
-      color: '#FFFFFF',
+      color: '#ffffff',
     },
     header: {
       main: '#252526',

--- a/desktop-app/app/components/useCreateTheme.js
+++ b/desktop-app/app/components/useCreateTheme.js
@@ -28,6 +28,9 @@ const lightTheme = {
       l10: '#d2d2d2',
       l20: '#8a8a8a',
     },
+    border: {
+      color: '#000000',
+    },
     header: {
       main: '#F5F5F5',
     },
@@ -67,6 +70,9 @@ const darkTheme = {
       l5: '#8a8a8a',
       l10: '#9e9e9e',
       l20: '#aeaeae',
+    },
+    border: {
+      color: '#FFFFFF',
     },
     header: {
       main: '#252526',

--- a/desktop-app/app/utils/TextAreaWithCopyButton.js
+++ b/desktop-app/app/utils/TextAreaWithCopyButton.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
     height: '40vh',
     marginBottom: '10px',
     marginTop: '10px',
-    border: '1px white solid',
+    border: `1px solid ${theme.palette.border.color}`,
     padding: '0 10px',
     borderRadius: '4px',
   },


### PR DESCRIPTION
**What does this PR contain:** 
- Fixes broken error boundary page in light theme

**Cause:**
- The `ErrorBoundary` component did not have a background applied in light theme.

**Fix:** 
- Used the default theme background for the error boundary component.
- The `TextAreaWithCopyButton` only had a border for the dark theme and did not have a border for the light theme. So created theme wide border colour and applied to both dark and white themes.

**Light Theme:**
![image](https://user-images.githubusercontent.com/4656109/94041651-27c9d480-fde8-11ea-8680-0899cdcebd31.png)

**Dark Theme:**
![image](https://user-images.githubusercontent.com/4656109/94041667-2f897900-fde8-11ea-8b3f-b9986f9370b9.png)


