### PR TITLE
 alert user that ssl validation can be disabled

### DIFF
--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -47,6 +47,7 @@ import Unfocus from '../icons/Unfocus';
 import {captureOnSentry} from '../../utils/logUtils';
 import {getBrowserSyncEmbedScriptURL} from '../../services/browserSync';
 import Spinner from '../Spinner';
+import {isSslValidationFailed} from '../../utils/generalUtils';
 
 const {BrowserWindow} = remote;
 
@@ -995,13 +996,12 @@ class WebView extends Component {
               <p className={cx(styles.errorDesc)}>Proxy Authentication Error</p>
             )}
 
-            {errorCode <= -200 && errorCode >= -299 && (
+            {isSslValidationFailed(errorCode) && (
               <p className={cx(styles.errorHelpSuggestion)}>
                 If you wish to proceed, you can disable the SSL validation in
                 the user preferences.
               </p>
             )}
-            
           </div>
           {this._getWebViewTag(deviceStyles, containerWidth, containerHeight)}
         </div>

--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -990,9 +990,18 @@ class WebView extends Component {
           >
             <p>ERROR: {errorCode}</p>
             <p className={cx(styles.errorDesc)}>{errorDesc}</p>
+
             {proxyAuthError && (
               <p className={cx(styles.errorDesc)}>Proxy Authentication Error</p>
             )}
+
+            {errorCode <= -200 && errorCode >= -299 && (
+              <p className={cx(styles.errorHelpSuggestion)}>
+                If you wish to proceed, you can disable the SSL validation in
+                the user preferences.
+              </p>
+            )}
+            
           </div>
           {this._getWebViewTag(deviceStyles, containerWidth, containerHeight)}
         </div>

--- a/desktop-app/app/components/WebView/style.module.css
+++ b/desktop-app/app/components/WebView/style.module.css
@@ -64,6 +64,16 @@
   font-size: 20px;
 }
 
+.errorHelpSuggestion {
+  position: absolute;
+  top: 25%;
+  width: 100%;
+  padding: 35px;
+  text-align: justify;
+  letter-spacing: -1.3px;
+  background: darkcyan;
+}
+
 .iconWrapperS {
   width: 100%;
   height: 15px;

--- a/desktop-app/app/components/WebView/style.module.css
+++ b/desktop-app/app/components/WebView/style.module.css
@@ -69,8 +69,6 @@
   top: 25%;
   width: 100%;
   padding: 35px;
-  text-align: justify;
-  letter-spacing: -1.3px;
   background: darkcyan;
 }
 

--- a/desktop-app/app/utils/generalUtils.js
+++ b/desktop-app/app/utils/generalUtils.js
@@ -36,3 +36,9 @@ export const getEnvironmentInfo = () => {
     osInfo,
   };
 };
+
+export function isSslValidationFailed(errorCode) {
+  const FirstSSLError = -200;
+  const LastSSLError = -299;
+  return errorCode <= FirstSSLError && errorCode >= LastSSLError;
+}


### PR DESCRIPTION
Alert user that ssl validation can be disabled whenever the page load fails because of ssl validation.
These commits implements changes suggested under Issue #403.
![ssl](https://user-images.githubusercontent.com/26111211/94614562-47587580-029e-11eb-957a-c50742a883d7.png)

I have test my work using the web site badssl.com. This site provide urls that produce ssl errors.you can use them and check for result.

here are the errors i've tested:

-200:CERT_COMMON_NAME_INVALID
The server responded with a certificate whose common name did not match the host name.
tested using this url https://wrong.host.badssl.com/

-201:CERT_DATE_INVALID
The server responded with a certificate that, by our clock, appears to either not yet be valid or to have expired.
tested using this url expired.badssl.com

-202:CERT_AUTHORITY_INVALID	
The server responded with a certificate that is signed by an authority we don't trust.
tested using this url https://self-signed.badssl.com/   

-206:CERT_REVOKED     
The server responded with a certificate has been revoked.
tested using this url https://revoked.badssl.com/  

-215:CERT_SYMANTEC_LEGACY     
The certificate chained to a legacy Symantec root that is no longer trusted.
tested using this url https://invalid-expected-sct.badssl.com/  
 
-208:CERT_WEAK_SIGNATURE_ALGORITHM   
The server responded with a certificate that is signed using a weak signature algorithm.
tested using this url https://sha1-intermediate.badssl.com/ 

