### PR TITLE
fix link on proxy manager modal on light theme

### DIFF
--- a/desktop-app/app/components/NetworkProxy/ProxyManager/index.js
+++ b/desktop-app/app/components/NetworkProxy/ProxyManager/index.js
@@ -96,7 +96,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: 0,
   },
   wilcardsAndMoreLink: {
-    color: 'white',
+    color: theme.palette.text.normal,
     textDecoration: 'underline',
   },
   bypassListField: {


### PR DESCRIPTION
**Light Theme**

Before:
![image](https://user-images.githubusercontent.com/13673443/95095725-b238ff00-072b-11eb-8ea7-f894be68d9d8.png)



After:
![image](https://user-images.githubusercontent.com/13673443/95095672-a0575c00-072b-11eb-8f3e-e3638bc717f7.png)


**Dark Theme**

Before:
![image](https://user-images.githubusercontent.com/13673443/95096456-91bd7480-072c-11eb-8677-5e04894a7880.png)



After:
![image](https://user-images.githubusercontent.com/13673443/95096397-7f433b00-072c-11eb-9ec9-0392df24b73c.png)

