### PR TITLE
bugfix(desktop-app): fix dev tolls overlapping device drawer

### DIFF
--- a/desktop-app/app/components/DeviceManager/index.js
+++ b/desktop-app/app/components/DeviceManager/index.js
@@ -115,7 +115,10 @@ function DeviceManager(props) {
         color="primary"
         aria-label="upload picture"
         component="span"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          props.onDevToolsClose(null, true);
+          setOpen(true);
+        }}
         className={styles.editButton}
       >
         Customize


### PR DESCRIPTION
### 📓 Referenced Issue

Closes: #509

### ℹ️ About the PR

Closes the dev tools before opening the device drawer.

### 🖼️ Testing Scenarios / Screenshots

![fix-dev-tools-overlap-device-drawer](https://user-images.githubusercontent.com/4656109/95679753-8f5a8f00-0bf2-11eb-915f-c7e8c5f8f398.gif)

