### PR TITLE
Add toggle spellcheck

### DIFF
--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -125,7 +125,14 @@ function UserPreference({
               />
             }
             label={
-              <span className={classes.preferenceName}>Disable spellcheck</span>
+              <div>
+                <span className={classes.preferenceName}>
+                  Disable spellcheck
+                </span>
+                <p className={classes.spellCheckToggleSmallNote}>
+                  Note: Restart required
+                </p>
+              </div>
             }
           />
         </div>

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -112,6 +112,23 @@ function UserPreference({
             }
           />
         </div>
+        <div>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={userPreferences.disableSpellCheck || false}
+                onChange={e => {
+                  onChange('disableSpellCheck', e.target.checked);
+                }}
+                name="Disable spellcheck"
+                color="primary"
+              />
+            }
+            label={
+              <span className={classes.preferenceName}>Disable spellcheck</span>
+            }
+          />
+        </div>
       </div>
       <div className={commonClasses.sidebarContentSectionContainer}>
         <div

--- a/desktop-app/app/components/UserPreferences/useStyles.js
+++ b/desktop-app/app/components/UserPreferences/useStyles.js
@@ -41,6 +41,11 @@ const useStyles = makeStyles(theme => ({
     lineHeight: 1.66,
     letterSpacing: '0.03333em',
   },
+  spellCheckToggleSmallNote: {
+    color: theme.palette.text.primary,
+    margin: 0,
+    fontSize: '10px',
+  },
 }));
 
 export default useStyles;

--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -893,6 +893,11 @@ class WebView extends Component {
           src={address || 'about:blank'}
           useragent={useragent}
           style={deviceStyles}
+          webpreferences={
+            this.props.browser.userPreferences.disableSpellCheck
+              ? 'spellcheck=no'
+              : 'spellcheck=yes'
+          }
         />
       </>
     );

--- a/desktop-app/app/reducers/browser.js
+++ b/desktop-app/app/reducers/browser.js
@@ -124,6 +124,7 @@ type PageMetaType = {
 type UserPreferenceType = {
   disableSSLValidation: boolean,
   reopenLastAddress: boolean,
+  disableSpellCheck: boolean,
   drawerState: boolean,
   devToolsOpenMode: DevToolsOpenModeType,
   deviceOutlineStyle: string,


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Resolves #531 

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

The solution adds a user preference checkbox to allow the user to enable/disable the spellchecking that is active after entering design mode. Right now, toggling the setting does **not** have effect after the webview/device window has already been created. A restart of the app can work around that (there's a note in the user preferences view - the user will probably only touch this once).

### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->

![bilde](https://user-images.githubusercontent.com/58193703/102766630-bbc32200-437e-11eb-822f-f9409707c583.png)
![bilde](https://user-images.githubusercontent.com/58193703/102766699-db5a4a80-437e-11eb-94a1-4aa06d69de4a.png)

Tested this based on the description and video from the referenced issue: checking the spellcheck functionality by enabling Design Mode in the app. Tested in WIndows 10 only.
