### PR TITLE
#553 - Fix missing horizontal scrollbar

### DIFF
--- a/desktop-app/app/containers/Browser/index.js
+++ b/desktop-app/app/containers/Browser/index.js
@@ -17,7 +17,7 @@ const Browser = ({browser}) => (
   <Fragment>
     {os.platform() === 'darwin' && <HorizontalSpacer />}
     <HeaderContainer />
-    <div style={{display: 'flex', height: '100%'}}>
+    <div style={{display: 'flex', height: '100%', overflow: 'auto'}}>
       <LeftIconsPaneContainer />
       <div
         style={{


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes #553 

### ℹ️ About the PR

This PR fixes a scenario where the layout is set to horizontal and the content overflows horizontally but there is no horizontal scrollbar. Tested on Windows and with the same specs as reported in the issue (re devices and zoom). Also tested with other devices and zoom properties to ensure the vertical and horizontal scrollbars appear and disappear as expected, depending on the size of the content.

### 🖼️ Testing Scenarios / Screenshots

**Scenario 1:**
5 devices, zoom 60%, content overflows horizontally and vertically => both scrollbars appear

![screenshot1](https://user-images.githubusercontent.com/46979603/106461646-58580400-6495-11eb-88ec-c8af823ced61.jpg)

**Scenario 2:**
3 devices, zoom 50%, content fits inside the container => no scrollbar visible

![screenshot2](https://user-images.githubusercontent.com/46979603/106461652-5a21c780-6495-11eb-94d2-7d0b37bca9b8.jpg)

**Scenario 3:**
5 devices, zoom 30%, content overflows horizontally => horizontal scrollbar appears

![screenshot3](https://user-images.githubusercontent.com/46979603/106461659-5beb8b00-6495-11eb-9221-4ccf446c36b8.jpg)

**Scenario 4:**
2 devices, zoom 50%, content overflows vertically => vertical scrollbar appears

![screenshot4](https://user-images.githubusercontent.com/46979603/106463126-49725100-6497-11eb-8b74-7e2bce7fd0e7.jpg)
