### PR TITLE
Add option to switch between blank page and homepage when app launches

### DIFF
--- a/desktop-app/app/actions/browser.js
+++ b/desktop-app/app/actions/browser.js
@@ -52,6 +52,7 @@ export const TOGGLE_DEVICE_DESIGN_MODE = 'TOGGLE_DEVICE_DESIGN_MODE';
 export const SET_HEADER_VISIBILITY = 'SET_HEADER_VISIBILITY';
 export const SET_LEFT_PANE_VISIBILITY = 'SET_LEFT_PANE_VISIBILITY';
 export const SET_HOVERED_LINK = 'SET_HOVERED_LINK';
+export const SET_STARTUP_PAGE = 'SET_STARTUP_PAGE';
 
 export function newAddress(address) {
   return {
@@ -926,5 +927,18 @@ export function setHoveredLink(url) {
   return {
     type: SET_HOVERED_LINK,
     url,
+  };
+}
+
+export function setStartupPage(value: 'BLANK' | 'HOME') {
+  return {
+    type: SET_STARTUP_PAGE,
+    value,
+  };
+}
+
+export function changeStartupPage(value: 'BLANK' | 'HOME') {
+  return (dispatch: Dispatch, getState: RootStateType) => {
+    dispatch(setStartupPage(value));
   };
 }

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -16,7 +16,7 @@ import {DEVTOOLS_MODES} from '../../constants/previewerLayouts';
 import {LIGHT_THEME, DARK_THEME} from '../../constants/theme';
 import ScreenShotSavePreference from '../ScreenShotSavePreference/index';
 import {userPreferenceSettings} from '../../settings/userPreferenceSettings';
-import {SCREENSHOT_MECHANISM} from '../../constants/values';
+import {SCREENSHOT_MECHANISM, STARTUP_PAGE} from '../../constants/values';
 import {notifyPermissionPreferenceChanged} from '../../utils/permissionUtils.js';
 import {PERMISSION_MANAGEMENT_OPTIONS} from '../../constants/permissionsManagement';
 import {setTheme} from '../../actions/browser';
@@ -36,6 +36,17 @@ function UserPreference({
     () => themeOptions.find(option => option.value === themeSource),
     [themeSource]
   );
+
+  const startupPageOptions = [
+    {
+      label: 'Homepage',
+      value: STARTUP_PAGE.HOME,
+    },
+    {
+      label: 'Blank Page',
+      value: STARTUP_PAGE.BLANK,
+    },
+  ];
 
   const onChange = (field, value) => {
     onUserPreferencesChange({...userPreferences, [field]: value});
@@ -269,6 +280,29 @@ function UserPreference({
             <strong>Note:</strong> To ensure this behaviour you should restart
             Responsively
           </p>
+        </div>
+      </div>
+      <div className={commonClasses.sidebarContentSectionContainer}>
+        <div
+          className={cx(
+            commonClasses.flexAlignVerticalMiddle,
+            classes.sectionHeader
+          )}
+        >
+          Startup Page
+        </div>
+        <div className={classes.marginTop}>
+          <Select
+            options={startupPageOptions}
+            value={
+              startupPageOptions.find(
+                x => x.value === userPreferences?.startupPage
+              ) || startupPageOptions[0]
+            }
+            onChange={val => {
+              onChange('startupPage', val.value);
+            }}
+          />
         </div>
       </div>
       <div className={commonClasses.sidebarContentSectionContainer}>

--- a/desktop-app/app/constants/values.js
+++ b/desktop-app/app/constants/values.js
@@ -12,3 +12,8 @@ export const DESIGN_MODE_JS_VALUES = {
   ON: 'on',
   OFF: 'off',
 };
+
+export const STARTUP_PAGE = {
+  BLANK: 'BLANK',
+  HOME: 'HOME',
+};

--- a/desktop-app/app/main.dev.js
+++ b/desktop-app/app/main.dev.js
@@ -32,6 +32,7 @@ import installExtension, {
 import fs from 'fs';
 import MenuBuilder from './menu';
 import {USER_PREFERENCES, NETWORK_CONFIGURATION} from './constants/settingKeys';
+import {STARTUP_PAGE} from './constants/values';
 import {migrateDeviceSchema} from './settings/migration';
 import {DEVTOOLS_MODES} from './constants/previewerLayouts';
 import {initMainShortcutManager} from './shortcut-manager/main-shortcut-manager';
@@ -54,6 +55,7 @@ import appMetadata from './services/db/appMetadata';
 import {convertToProxyConfig} from './utils/proxyUtils';
 import {PERMISSION_MANAGEMENT_OPTIONS} from './constants/permissionsManagement';
 import {endSession, startSession} from './utils/analytics';
+import {getStartupPage, getLastOpenedAddress} from './utils/navigatorUtils';
 
 const path = require('path');
 const URL = require('url').URL;
@@ -307,14 +309,6 @@ function getUserPreferences(): UserPreferenceType {
   return settings.get(USER_PREFERENCES) || {};
 }
 
-function getLastOpenedAddress() {
-  return settings.get(LAST_OPENED_ADDRESS) || getHomepage();
-}
-
-function getHomepage() {
-  return settings.get(HOME_PAGE) || 'https://www.google.com/';
-}
-
 const createWindow = async () => {
   appMetadata.incrementOpenCount();
   hasActiveWindow = true;
@@ -393,7 +387,7 @@ const createWindow = async () => {
       openUrl(
         getUserPreferences().reopenLastAddress
           ? getLastOpenedAddress()
-          : getHomepage()
+          : getStartupPage()
       );
       mainWindow.show();
     }

--- a/desktop-app/app/reducers/browser.js
+++ b/desktop-app/app/reducers/browser.js
@@ -31,6 +31,7 @@ import {
   SET_HEADER_VISIBILITY,
   SET_LEFT_PANE_VISIBILITY,
   SET_HOVERED_LINK,
+  SET_STARTUP_PAGE,
 } from '../actions/browser';
 import {
   CHANGE_ACTIVE_THROTTLING_PROFILE,
@@ -59,6 +60,7 @@ import {
   getHomepage,
   saveHomepage,
   saveLastOpenedAddress,
+  saveStartupPage,
 } from '../utils/navigatorUtils';
 import {updateExistingUrl} from '../services/searchUrlSuggestions';
 import {normalizeZoomLevel} from '../utils/browserUtils';
@@ -601,6 +603,9 @@ export default function browser(
         ...state,
         hoveredLink: action.url,
       };
+    case SET_STARTUP_PAGE:
+      saveStartupPage(action.value);
+      return {...state};
     default:
       return state;
   }

--- a/desktop-app/app/settings/migration.js
+++ b/desktop-app/app/settings/migration.js
@@ -5,7 +5,7 @@ import {
   NETWORK_CONFIGURATION,
   LAYOUT,
 } from '../constants/settingKeys';
-import {SCREENSHOT_MECHANISM} from '../constants/values';
+import {SCREENSHOT_MECHANISM, STARTUP_PAGE} from '../constants/values';
 import {PERMISSION_MANAGEMENT_OPTIONS} from '../constants/permissionsManagement';
 import {DARK_THEME} from '../constants/theme';
 import {FLEXIGRID_LAYOUT} from '../constants/previewerLayouts';
@@ -23,6 +23,16 @@ export function migrateDeviceSchema() {
   _handlePermissionsDefaultPreferences();
   _handleColorThemePreferences();
   _handleLayout();
+  _ensureDefaultStartupPage();
+}
+
+function _ensureDefaultStartupPage() {
+  const userPreferences = settings.get(USER_PREFERENCES) || {};
+  const defaultStartupPage = userPreferences.startupPage;
+  if (defaultStartupPage != null) return;
+
+  userPreferences.startupPage = STARTUP_PAGE.HOME;
+  settings.set(USER_PREFERENCES, userPreferences);
 }
 
 function _ensureDefaultNetworkConfig() {

--- a/desktop-app/app/utils/navigatorUtils.js
+++ b/desktop-app/app/utils/navigatorUtils.js
@@ -1,5 +1,7 @@
 import settings from 'electron-settings';
 import path from 'path';
+import {STARTUP_PAGE} from '../constants/values';
+import {USER_PREFERENCES} from '../constants/settingKeys';
 
 const HOME_PAGE = 'HOME_PAGE';
 const LAST_OPENED_ADDRESS = 'LAST_OPENED_ADDRESS';
@@ -17,5 +19,17 @@ export function getHomepage() {
 }
 
 export function getLastOpenedAddress() {
-  return settings.get(LAST_OPENED_ADDRESS) || getHomepage();
+  return settings.get(LAST_OPENED_ADDRESS) || getStartupPage();
+}
+
+export function getStartupPage() {
+  const startupPage = settings.get(USER_PREFERENCES).startupPage;
+  if (startupPage === STARTUP_PAGE.BLANK) return 'about:blank';
+  return getHomepage();
+}
+
+export function saveStartupPage(option: 'BLANK' | 'HOME') {
+  const preferences = settings.get(USER_PREFERENCES);
+  preferences.startupPage = option;
+  settings.set(USER_PREFERENCES, preferences);
 }

--- a/desktop-app/app/utils/urlUtils.js
+++ b/desktop-app/app/utils/urlUtils.js
@@ -10,7 +10,7 @@ export function getHostFromURL(url: String) {
 }
 
 export const normalize = (address: string) => {
-  if (address.indexOf('://') === -1) {
+  if (address !== 'about:blank' && address.indexOf('://') === -1) {
     let protocol = 'https://';
     if (
       address.startsWith('localhost') ||


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

resolves #521 

### ℹ️ About the PR

Added a select to User Preferences to set between blank page and homepage as startup page when app launches

### 🖼️ Testing Scenarios / Screenshots

![image](https://user-images.githubusercontent.com/13673443/118545365-c7ace780-b756-11eb-84ed-a9ccfe9f6d91.png)


❗ An scrollbar appeared, maybe it's time to reorder the left menu 👀
I tried with a checkbox like "Use blank page instead of homepage when app launches" but it take two lines and the scrollbar appeared too

![image](https://user-images.githubusercontent.com/13673443/118545665-338f5000-b757-11eb-92ce-bb257d86dc40.png)

and another version:

![image](https://user-images.githubusercontent.com/13673443/118545837-705b4700-b757-11eb-802e-a098a8686c7f.png)


I think we could go like this and then reorder the whole sidebar

