### PR TITLE
fix notification styles

### DIFF
--- a/desktop-app/app/components/AppNotification/styles.module.css
+++ b/desktop-app/app/components/AppNotification/styles.module.css
@@ -11,6 +11,7 @@
   min-width: 250px;
   max-width: 320px;
   color: #f8f8f8;
+  z-index: 2;
 }
 
 .titleContainer {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
resolves #584 

### ℹ️ About the PR

Responsively notification get behind of <webview/> when navigation resulted in error. 
This PR just fix the notification `z-index` value (`[notification z-index] = [webview z-index] + 1`)

### 🖼️ Testing Scenarios / Screenshots

**BEFORE**:

![image](https://user-images.githubusercontent.com/13673443/118959075-45910e80-b962-11eb-917b-a86c2e837bab.png)


**AFTER**

![image](https://user-images.githubusercontent.com/13673443/118959107-4b86ef80-b962-11eb-9ec1-dabb4d252a90.png)
