### PR TITLE
fix browserSync usage

### DIFF
--- a/desktop-app/app/main.dev.js
+++ b/desktop-app/app/main.dev.js
@@ -117,10 +117,12 @@ const openWithHandler = filePath => {
   fileToOpen = null;
   if (
     filePath != null &&
+    !filePath.startsWith('http://') &&
+    !filePath.startsWith('https://') &&
     (filePath.endsWith('.html') || filePath.endsWith('.htm'))
   ) {
-    const url = `file://${filePath}`;
-    fileToOpen = url;
+    if (filePath.startsWith('file://')) fileToOpen = filePath;
+    else fileToOpen = `file://${filePath}`;
     return true;
   }
   return false;
@@ -156,7 +158,10 @@ app.on('will-finish-launching', () => {
     !urlToOpen &&
     process.argv.length >= 2 &&
     !openWithHandler(process.argv[1]) &&
-    isURL(process.argv[1], {protocols: ['http', 'https', 'file']})
+    isURL(process.argv[1], {
+      protocols: ['http', 'https', 'file'],
+      require_tld: false,
+    })
   ) {
     urlToOpen = process.argv[1];
   }
@@ -284,7 +289,8 @@ const chooseOpenWindowHandler = url => {
 
   if (url === 'about:blank') return 'useWindow';
 
-  if (isURL(url, {protocols: ['http', 'https']})) return 'useWindow';
+  if (isURL(url, {protocols: ['http', 'https'], require_tld: false}))
+    return 'useWindow';
 
   let urlObj = null;
   try {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

resolves #540 and resolves #608

### ℹ️ About the PR
After the changes made on #586, the issue #540 should have been resolved. Testing it I found other problems detecting when the argument passed as a parameter to the app was an URL or a file.

After these changes, at least in Windows I have been able to verify that #540 is resolved. It would be good to test it on mac and linux (cc: @manojVivek )

### 🖼️ Testing Scenarios / Screenshots

I used the following `gulpfile.js` on Windows

```js
const { series } = require('gulp');
const browserSync = require('browser-sync').create();

function serve(done) {
  browserSync.init({
    port: 3000,
    server: true,
    startPath: 'index.html'
    // browser: "responsivelyapp",
    browser: "%LOCALAPPDATA%\\Programs\\Responsively-App\\ResponsivelyApp.exe"
  });
  done();
}
function defaultTask(done) {
  const startupTasks = series(
    serve,
  );
  startupTasks();
}
exports.default = defaultTask
```

the directory looks like:
```
test
|   gulpfile.js
|   index.html
|   package.json
|   yarn.lock
|   
\---node_modules
    |   
    +--- oo
    
```

and running `gulp` opens *responsively* and navigates to `http://localhost:3000/index.html` as expected

