### PR TITLE
Replace special characters from screenshot file name

### DIFF
--- a/desktop-app/app/components/WebView/screenshotUtil.js
+++ b/desktop-app/app/components/WebView/screenshotUtil.js
@@ -416,6 +416,7 @@ function _getScreenshotFileName(
     .toUpperCase()}`;
   const directoryPath = createSeparateDir ? `${dateString}/` : '';
   const userSelectedScreenShotSavePath = userPreferenceSettings.getScreenShotSavePath();
+  const specialCharactersRegex = /["\\/*|:?<>]/g;
   return {
     dir: path.join(
       userSelectedScreenShotSavePath ||
@@ -424,7 +425,7 @@ function _getScreenshotFileName(
     ),
     file: `${getWebsiteName(address)} ${
       fullScreen ? '- Full ' : ''
-    }- ${device.name.replace(/\//g, '-')} - ${dateString}.${format}`,
+    }- ${device.name.replace(/\//g, '-').replace(specialCharactersRegex, '')} - ${dateString}.${format}`,
   };
 }
 


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
Fixes: #624 

### ℹ️ About the PR
This PR fixes the problem where we are unable to take screeshots of pages in devices with special characters in their names. This PR solves it by replacing those characters for empty string when resolving the output file name.

I handled the special characters which are forbidden in file names on Windows system. Probably the are (almost) the same on unix systems and MacOS (not sure though):
![image](https://user-images.githubusercontent.com/10589421/134729839-2b8560ef-85f0-44ba-acb8-facd59a33302.png)


### 🖼️ Testing Scenarios / Screenshots
1. Tested with MacBook Pro xx"
![image](https://user-images.githubusercontent.com/10589421/134730520-6b5381a7-237f-4df4-a7a9-3208dab585bd.png)
![image](https://user-images.githubusercontent.com/10589421/134730548-08925360-eabe-4630-b196-a427c262eaf1.png)

2. Tested with custom device
![image](https://user-images.githubusercontent.com/10589421/134730820-bcf519de-0822-4c5b-bf5f-8269cf1962a5.png)
![image](https://user-images.githubusercontent.com/10589421/134730836-10d60574-4320-4fe9-b550-3fed64c97d6d.png)
