### PR TITLE
Fixed the quick filter active color on Dark Mode

### DIFF
--- a/desktop-app/app/components/QuickFilterDevices/index.js
+++ b/desktop-app/app/components/QuickFilterDevices/index.js
@@ -155,7 +155,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     ...theme.palette.mode({
       light: {},
-      dark: {background: '#000000b0'},
+      dark: {},
     }),
     '& svg': {
       padding: '5px',


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #627 

### ℹ️ About the PR

The background was statically set to #000000b0 and this was preventing the active color from displaying when the "makeStyles-iconSelected" utility class is applied to the buttons.

By removing this background color, the experience is the same as the way it works in light mode.

### 🖼️ Testing Scenarios / Screenshots

I removed the static value, rebuilt the application, and verified that the active color indicator is now working properly (see below):

https://user-images.githubusercontent.com/50255197/136371782-86ab1996-e6aa-4ecc-80ca-a27553fb5c36.mp4
