### PR TITLE
Export and import preferences

### DIFF
--- a/desktop-app/app/actions/browser.js
+++ b/desktop-app/app/actions/browser.js
@@ -710,7 +710,7 @@ export function uploadPreferences() {
     remote.dialog
       .showOpenDialog({
         title: 'Select user configuration file',
-        buttonLabel: 'Upload',
+        buttonLabel: 'Upload File',
         filters: [
           {
             name: 'Json file',

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -19,8 +19,14 @@ import {userPreferenceSettings} from '../../settings/userPreferenceSettings';
 import {SCREENSHOT_MECHANISM, STARTUP_PAGE} from '../../constants/values';
 import {notifyPermissionPreferenceChanged} from '../../utils/permissionUtils.js';
 import {PERMISSION_MANAGEMENT_OPTIONS} from '../../constants/permissionsManagement';
-import {setTheme} from '../../actions/browser';
+import {
+  setTheme,
+  downloadPreferences,
+  uploadPreferences,
+} from '../../actions/browser';
 import {deleteSearchResults} from '../../services/searchUrlSuggestions';
+import FileDownloadIcon from '@material-ui/icons/CloudDownload';
+import FileUploadIcon from '@material-ui/icons/CloudUpload';
 
 function UserPreference({
   devToolsConfig,
@@ -31,7 +37,8 @@ function UserPreference({
   const classes = useStyles();
   const commonClasses = useCommonStyles();
   const dispatch = useDispatch();
-  const themeSource = useSelector(state => state.browser.theme);
+  const state = useSelector(state => state.browser);
+  const themeSource = state.theme;
   const selectedThemeOption = useMemo(
     () => themeOptions.find(option => option.value === themeSource),
     [themeSource]
@@ -52,6 +59,26 @@ function UserPreference({
     onUserPreferencesChange({...userPreferences, [field]: value});
   };
 
+  const downloadConfiguration = () => {
+    console.log();
+    const configuration = {
+      devices: state.devices,
+      homepage: state.homepage,
+      userPreferences: state.userPreferences,
+      customDevices: state.allDevices.slice(
+        0,
+        state.allDevices.findIndex(item => item.id === '1')
+      ),
+    };
+    const data = JSON.stringify(configuration);
+    const blob = new Blob([data], {type: 'application/json'});
+    const url = window.URL.createObjectURL(blob);
+    dispatch(downloadPreferences(url));
+  };
+
+  const uploadConfiguration = () => {
+    dispatch(uploadPreferences());
+  };
   return (
     <div className={commonClasses.sidebarContentSection}>
       <div className={commonClasses.sidebarContentSectionTitleBar}>
@@ -323,6 +350,39 @@ function UserPreference({
             onClick={deleteSearchResults}
           >
             Clear Address History
+          </Button>
+        </div>
+        <div
+          className={cx(
+            commonClasses.flexAlignVerticalMiddle,
+            classes.sectionHeader
+          )}
+        >
+          Import / Export preferences
+        </div>
+        <div
+          className={cx(
+            commonClasses.sidebarContentSectionContainer,
+            classes.exportPreferencesButtons
+          )}
+        >
+          <Button
+            variant="contained"
+            color="secondary"
+            aria-label="download preferences"
+            component="span"
+            onClick={downloadConfiguration}
+          >
+            <FileDownloadIcon />
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            aria-label="upload preferences"
+            component="span"
+            onClick={uploadConfiguration}
+          >
+            <FileUploadIcon />
           </Button>
         </div>
       </div>

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -89,10 +89,10 @@ function UserPreference({
       >
         <SettingsIcon width={26} margin={2} /> User Preferences
         <KebabMenu>
-          <div>
+          <div className={classes.containerImportButton}>
             <Button
               variant="contained"
-              color="secondary"
+              color="primary"
               aria-label="download preferences"
               component="span"
               onClick={downloadConfiguration}
@@ -101,10 +101,10 @@ function UserPreference({
               <FileDownloadIcon />
             </Button>
           </div>
-          <div>
+          <div className={classes.containerImportButton}>
             <Button
               variant="contained"
-              color="secondary"
+              color="primary"
               aria-label="upload preferences"
               component="span"
               onClick={uploadConfiguration}

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -60,7 +60,6 @@ function UserPreference({
   };
 
   const downloadConfiguration = () => {
-    console.log();
     const configuration = {
       devices: state.devices,
       homepage: state.homepage,

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -8,6 +8,9 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Input from '@material-ui/core/Input';
 import SettingsIcon from '@material-ui/icons/Settings';
+import FileDownloadIcon from '@material-ui/icons/CloudDownload';
+import FileUploadIcon from '@material-ui/icons/CloudUpload';
+import KebabMenu from '../KebabMenu';
 
 import useCommonStyles from '../useCommonStyles';
 import useStyles from './useStyles';
@@ -25,8 +28,6 @@ import {
   uploadPreferences,
 } from '../../actions/browser';
 import {deleteSearchResults} from '../../services/searchUrlSuggestions';
-import FileDownloadIcon from '@material-ui/icons/CloudDownload';
-import FileUploadIcon from '@material-ui/icons/CloudUpload';
 
 function UserPreference({
   devToolsConfig,
@@ -80,8 +81,39 @@ function UserPreference({
   };
   return (
     <div className={commonClasses.sidebarContentSection}>
-      <div className={commonClasses.sidebarContentSectionTitleBar}>
+      <div
+        className={cx(
+          commonClasses.sidebarContentSectionTitleBar,
+          classes.exportPreferencesButtons
+        )}
+      >
         <SettingsIcon width={26} margin={2} /> User Preferences
+        <KebabMenu>
+          <div>
+            <Button
+              variant="contained"
+              color="secondary"
+              aria-label="download preferences"
+              component="span"
+              onClick={downloadConfiguration}
+            >
+              <span className={classes.importAndExportLabels}>Export</span>
+              <FileDownloadIcon />
+            </Button>
+          </div>
+          <div>
+            <Button
+              variant="contained"
+              color="secondary"
+              aria-label="upload preferences"
+              component="span"
+              onClick={uploadConfiguration}
+            >
+              <span className={classes.importAndExportLabels}>Import</span>
+              <FileUploadIcon />
+            </Button>
+          </div>
+        </KebabMenu>
       </div>
       <div className={commonClasses.sidebarContentSectionContainer}>
         <div
@@ -349,39 +381,6 @@ function UserPreference({
             onClick={deleteSearchResults}
           >
             Clear Address History
-          </Button>
-        </div>
-        <div
-          className={cx(
-            commonClasses.flexAlignVerticalMiddle,
-            classes.sectionHeader
-          )}
-        >
-          Import / Export preferences
-        </div>
-        <div
-          className={cx(
-            commonClasses.sidebarContentSectionContainer,
-            classes.exportPreferencesButtons
-          )}
-        >
-          <Button
-            variant="contained"
-            color="secondary"
-            aria-label="download preferences"
-            component="span"
-            onClick={downloadConfiguration}
-          >
-            <FileDownloadIcon />
-          </Button>
-          <Button
-            variant="contained"
-            color="secondary"
-            aria-label="upload preferences"
-            component="span"
-            onClick={uploadConfiguration}
-          >
-            <FileUploadIcon />
           </Button>
         </div>
       </div>

--- a/desktop-app/app/components/UserPreferences/index.js
+++ b/desktop-app/app/components/UserPreferences/index.js
@@ -89,30 +89,18 @@ function UserPreference({
       >
         <SettingsIcon width={26} margin={2} /> User Preferences
         <KebabMenu>
-          <div className={classes.containerImportButton}>
-            <Button
-              variant="contained"
-              color="primary"
-              aria-label="download preferences"
-              component="span"
-              onClick={downloadConfiguration}
-            >
+          <KebabMenu.Item onClick={downloadConfiguration}>
+            <div className={classes.containerImportButton}>
               <span className={classes.importAndExportLabels}>Export</span>
               <FileDownloadIcon />
-            </Button>
-          </div>
-          <div className={classes.containerImportButton}>
-            <Button
-              variant="contained"
-              color="primary"
-              aria-label="upload preferences"
-              component="span"
-              onClick={uploadConfiguration}
-            >
+            </div>
+          </KebabMenu.Item>
+          <KebabMenu.Item onClick={uploadConfiguration}>
+            <div className={classes.containerImportButton}>
               <span className={classes.importAndExportLabels}>Import</span>
               <FileUploadIcon />
-            </Button>
-          </div>
+            </div>
+          </KebabMenu.Item>
         </KebabMenu>
       </div>
       <div className={commonClasses.sidebarContentSectionContainer}>

--- a/desktop-app/app/components/UserPreferences/useStyles.js
+++ b/desktop-app/app/components/UserPreferences/useStyles.js
@@ -46,6 +46,10 @@ const useStyles = makeStyles(theme => ({
     margin: 0,
     fontSize: '10px',
   },
+  exportPreferencesButtons: {
+    display: 'flex',
+    justifyContent: 'space-around',
+  },
 }));
 
 export default useStyles;

--- a/desktop-app/app/components/UserPreferences/useStyles.js
+++ b/desktop-app/app/components/UserPreferences/useStyles.js
@@ -50,6 +50,10 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     justifyContent: 'space-around',
   },
+  importAndExportLabels: {
+    fontSize: '12px',
+    paddingRight: '1.5em',
+  },
 }));
 
 export default useStyles;

--- a/desktop-app/app/components/UserPreferences/useStyles.js
+++ b/desktop-app/app/components/UserPreferences/useStyles.js
@@ -55,7 +55,8 @@ const useStyles = makeStyles(theme => ({
     paddingRight: '1.5em',
   },
   containerImportButton: {
-    padding: '5px',
+    display: 'flex',
+    alignItems: 'center',
   },
 }));
 

--- a/desktop-app/app/components/UserPreferences/useStyles.js
+++ b/desktop-app/app/components/UserPreferences/useStyles.js
@@ -54,6 +54,9 @@ const useStyles = makeStyles(theme => ({
     fontSize: '12px',
     paddingRight: '1.5em',
   },
+  containerImportButton: {
+    padding: '5px',
+  },
 }));
 
 export default useStyles;

--- a/desktop-app/app/main.dev.js
+++ b/desktop-app/app/main.dev.js
@@ -681,6 +681,10 @@ const createWindow = async () => {
     devToolsView.setBounds(bounds);
   });
 
+  ipcMain.on('download-preferences', (event, ...args) => {
+    session.defaultSession.downloadURL(args[0].url);
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/desktop-app/app/reducers/browser.js
+++ b/desktop-app/app/reducers/browser.js
@@ -34,6 +34,7 @@ import {
   SET_STARTUP_PAGE,
   UPDATE_PAGE_NAVIGATOR,
   TOGGLE_PAGE_NAVIGATOR,
+  LOAD_CUSTOM_DEVICES,
 } from '../actions/browser';
 import {
   CHANGE_ACTIVE_THROTTLING_PROFILE,
@@ -450,6 +451,10 @@ export default function browser(
     case NEW_CUSTOM_DEVICE:
       const existingDevices = settings.get(CUSTOM_DEVICES) || [];
       settings.set(CUSTOM_DEVICES, [action.device, ...existingDevices]);
+      return {...state, allDevices: getAllDevices()};
+    case LOAD_CUSTOM_DEVICES:
+      const actualDevices = settings.get(CUSTOM_DEVICES);
+      settings.set(CUSTOM_DEVICES, [...action.devices, ...actualDevices]);
       return {...state, allDevices: getAllDevices()};
     case DELETE_CUSTOM_DEVICE:
       const existingCustomDevices = settings.get(CUSTOM_DEVICES) || [];


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
#656 
<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->

### ℹ️ About the PR
Added buttons to export and import user preferences. I preferred to do the download and upload of the json file from the main process, from the renderer process there is a problem with the redux extension in development mode (I think it is a better solution to do it from the main process). I would love to read the proposals to improve UX to export / import buttons and about the configuration file which is currently a JSON.

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

### 🖼️ Testing Scenarios / Screenshots
[Uploading a config file with 3 custom devices and darkmode](https://www.loom.com/share/31a609e9ba394336a1d0579a11bb66c4)

I tested exporting and importing configurations between windows (10) and Linux (Debian bullseye)
<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->
