### PR TITLE
Fix - Problem with right-docked devtools

### DIFF
--- a/desktop-app/app/components/DevToolsResizer/index.js
+++ b/desktop-app/app/components/DevToolsResizer/index.js
@@ -24,14 +24,14 @@ const getResizingDirections = mode => {
 
 const getResizerPosition = (mode, bounds) => {
   if (mode === DEVTOOLS_MODES.RIGHT) {
-    return {right: 0, top: 0};
+    return {right: 0, top: bounds.y - 30};
   }
   return {bottom: 0};
 };
 
 const getToolbarPosition = (mode, bounds) => {
   if (mode === DEVTOOLS_MODES.RIGHT) {
-    return {position: 'absolute', top: bounds.y - 20};
+    return {position: 'absolute', top: 0};
   }
   return {};
 };


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->

Fixes #530 

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

Change the resizer size and toolbar position to fix the non-clickable icons when devtools are right-docked.

### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->

![Animation](https://user-images.githubusercontent.com/28947061/170836131-675e6226-ed81-4242-86e5-6c19880f4139.gif)

