### PR TITLE
(Trivial spelling) Change the spelling of 'tilt' to 'rotate'

### DIFF
--- a/desktop-app/app/components/Renderer/index.js
+++ b/desktop-app/app/components/Renderer/index.js
@@ -81,7 +81,7 @@ function Renderer(props) {
               ])
             }
           >
-            Tilt Device
+            Rotate Device
           </KebabMenu.Item>
           <KebabMenu.Item
             onClick={props.device.isMuted ? _unmuteDevice : _muteDevice}

--- a/desktop-app/app/components/ScrollControls/index.js
+++ b/desktop-app/app/components/ScrollControls/index.js
@@ -163,7 +163,7 @@ const ScrollControls = ({
           </Tooltip>
         </Grid>
         <Grid item className={commonClasses.icon}>
-          <Tooltip title="Tilt Devices">
+          <Tooltip title="Rotate Devices">
             <div onClick={flipOrientationAllDevices}>
               <DeviceRotateIcon {...iconProps} />
             </div>

--- a/desktop-app/app/components/WebView/index.js
+++ b/desktop-app/app/components/WebView/index.js
@@ -60,7 +60,7 @@ const MESSAGE_TYPES = {
   click: 'click',
   openDevToolsInspector: 'openDevToolsInspector',
   openConsole: 'openConsole',
-  tiltDevice: 'tiltDevice',
+  rotateDevice: 'rotateDevice',
   takeScreenshot: 'takeScreenshot',
   toggleEventMirroring: 'toggleEventMirroring',
 };
@@ -72,7 +72,7 @@ class WebView extends Component {
     this.devToolsWebviewRef = createRef();
     this.state = {
       screenshotInProgress: false,
-      isTilted: false,
+      isRotated: false,
       isUnplugged: false,
       errorCode: null,
       errorDesc: null,
@@ -625,7 +625,7 @@ class WebView extends Component {
       case MESSAGE_TYPES.openConsole:
         this._toggleDevTools();
         return;
-      case MESSAGE_TYPES.tiltDevice:
+      case MESSAGE_TYPES.rotateDevice:
         this._flipOrientation();
         return;
       case MESSAGE_TYPES.takeScreenshot:
@@ -743,14 +743,14 @@ class WebView extends Component {
     if (!this.isMobile) return;
 
     if (this.props.sendFlipStatus) {
-      this.props.sendFlipStatus(!this.state.isTilted);
+      this.props.sendFlipStatus(!this.state.isRotated);
     }
     const flippedDeviceDims = {
       width: this.state.deviceDimensions.height,
       height: this.state.deviceDimensions.width,
     };
     this.setState({
-      isTilted: !this.state.isTilted,
+      isRotated: !this.state.isRotated,
       deviceDimensions: flippedDeviceDims,
     });
   };
@@ -887,7 +887,7 @@ class WebView extends Component {
       classes,
       device: {id, useragent, capabilities},
     } = this.props;
-    const {deviceDimensions, address, isTilted} = this.state;
+    const {deviceDimensions, address, isRotated} = this.state;
     const outlinePx = this.props.browser.userPreferences.deviceOutlineStyle
       ? 3
       : 0;

--- a/desktop-app/app/containers/Root.js
+++ b/desktop-app/app/containers/Root.js
@@ -161,8 +161,8 @@ export default class Root extends Component {
 
     registerShortcut(
       {
-        id: 'TiltDevices',
-        title: 'Tilt Devices',
+        id: 'RotateDevices',
+        title: 'Rotate Devices',
         accelerators: ['mod+tab'],
         index: 13,
       },

--- a/desktop-app/app/preload.js
+++ b/desktop-app/app/preload.js
@@ -18,9 +18,9 @@ menu.append(
 );
 menu.append(
   new MenuItem({
-    label: 'Tilt Device',
+    label: 'Rotate Device',
     click(menuItem, browserWindow, event) {
-      window.responsivelyApp.sendMessageToHost('tiltDevice');
+      window.responsivelyApp.sendMessageToHost('rotateDevice');
     },
   })
 );


### PR DESCRIPTION
In American English, the term for “change the orientation of the display by 90º” is “rotate.” See the Google searches [`apple rotate screen` at apple.rotate.screen.qggl.it](http://apple.rotate.screen.qggl.it) or [`samsung rotate screen` at samsung.rotate.screen.qggl.it](http://samsung.rotate.screen.qggl.it) and compare to [apple.tilt.screen.qggl.it](http://apple.tilt.screen.qggl.it) — the latter assumes you *meant* “rotate” instead of “tilt”! 

In the context of UI devices, “tilt” generally refers to <20º rotation, most often as a game control. It can refer to rotation around any of the x,y,z axes. If it’s a device with a display, “rotate” means a multiple of 90º around the z axis.

![tilt-to-rotate](https://user-images.githubusercontent.com/1357866/180873718-ac550b92-2bd9-413e-9537-98b25c199e0f.png)

