### PR TITLE
fix: allow whitespaces in device search (#869)

### DIFF
--- a/desktop-app/src/renderer/components/DeviceManager/index.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/index.tsx
@@ -15,9 +15,11 @@ import DeviceLabel, { DND_TYPE } from './DeviceLabel';
 import DeviceDetailsModal from './DeviceDetailsModal';
 
 const filterDevices = (devices: Device[], filter: string) => {
+  const sanitizedFilter = filter.trim().toLowerCase();
+
   return devices.filter((device: Device) =>
     `${device.name.toLowerCase()}${device.width}x${device.height}`.includes(
-      filter
+      sanitizedFilter
     )
   );
 };
@@ -108,11 +110,9 @@ const DeviceManager = () => {
             <Icon icon="ic:outline-search" height={24} />
             <input
               className="w-60 rounded bg-inherit px-2 py-1 focus:outline-none"
-              placeholder="Search.."
+              placeholder="Search ..."
               value={searchText}
-              onChange={(e) =>
-                setSearchText(e.target.value.trim().toLowerCase())
-              }
+              onChange={(e) => setSearchText(e.target.value)}
             />
           </div>
         </div>


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

fixes #869.

### ℹ️ About the PR

Search input is now stored "raw", input sanitization is done before filtering.

### 🖼️ Testing Scenarios / Screenshots

Whitespace characters can now be entered as expected, filtering result should not be affected.