### PR TITLE
Ability to Rotate Only One Device, Not All at Once

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -7,9 +7,12 @@ import { Device } from 'common/deviceList';
 import WebPage from 'main/screenshot/webpage';
 
 import screenshotSfx from 'renderer/assets/sfx/screenshot.mp3';
+import { selectRotate, setRotate } from 'renderer/store/features/renderer';
+import { useDispatch, useSelector } from 'react-redux';
 
 interface Props {
   webview: Electron.WebviewTag | null;
+  deviceID: string;
   device: Device;
   setScreenshotInProgress: (value: boolean) => void;
   openDevTools: () => void;
@@ -17,15 +20,19 @@ interface Props {
 
 const Toolbar = ({
   webview,
+  deviceID,
   device,
   setScreenshotInProgress,
   openDevTools,
+  
 }: Props) => {
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, { volume: 0.5 });
   const [screenshotLoading, setScreenshotLoading] = useState<boolean>(false);
   const [fullScreenshotLoading, setFullScreenshotLoading] =
     useState<boolean>(false);
+  const rotatedDevices = useSelector(selectRotate);
+  const dispatch = useDispatch();
 
   const toggleEventMirroring = async () => {
     if (webview == null) {
@@ -110,6 +117,24 @@ const Toolbar = ({
     setFullScreenshotLoading(false);
   };
 
+  const rotate = async () => {
+    try {
+      if (rotatedDevices[deviceID]) {
+        const obj = {...rotatedDevices};
+      
+        obj[deviceID] = {
+          inSingle: !(obj[deviceID].inSingle),
+          rotate: !(obj[deviceID].rotate)
+        };
+
+        dispatch(setRotate({...obj}));
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error while rotate single screen', error);
+    }
+  };
+
   return (
     <div className="my-1 flex items-center gap-1">
       <Button
@@ -145,6 +170,19 @@ const Toolbar = ({
       </Button>
       <Button onClick={openDevTools} title="Open Devtools">
         <Icon icon="ic:round-code" />
+      </Button>
+      <Button 
+        onClick={rotate}
+        isActive={rotatedDevices[deviceID]?.inSingle}
+        title="Rotate This Device"
+      >
+        <Icon
+          icon={
+            rotatedDevices[deviceID]?.inSingle
+              ? 'mdi:phone-rotate-portrait'
+              : 'mdi:phone-rotate-landscape'
+            }
+        />
       </Button>
     </div>
   );

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -24,14 +24,13 @@ const Toolbar = ({
   device,
   setScreenshotInProgress,
   openDevTools,
-  
 }: Props) => {
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, { volume: 0.5 });
   const [screenshotLoading, setScreenshotLoading] = useState<boolean>(false);
   const [fullScreenshotLoading, setFullScreenshotLoading] =
     useState<boolean>(false);
-  const rotatedDevices = useSelector(selectRotate);
+  const { devices, ...rotatedDevices } = useSelector(selectRotate);
   const dispatch = useDispatch();
 
   const toggleEventMirroring = async () => {
@@ -117,18 +116,20 @@ const Toolbar = ({
     setFullScreenshotLoading(false);
   };
 
-  const rotate = async () => {
+  const rotate = () => {
     try {
-      if (rotatedDevices[deviceID]) {
-        const obj = {...rotatedDevices};
-      
-        obj[deviceID] = {
-          inSingle: !(obj[deviceID].inSingle),
-          rotate: !(obj[deviceID].rotate)
-        };
-
-        dispatch(setRotate({...obj}));
+      if (!devices[deviceID]) {
+        return;
       }
+
+      const devicesCloneObj = { ...devices };
+
+      devicesCloneObj[deviceID] = {
+        inSingle: !devicesCloneObj[deviceID].inSingle,
+        rotate: !devicesCloneObj[deviceID].rotate,
+      };
+
+      dispatch(setRotate({ ...rotatedDevices, devices: devicesCloneObj }));
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Error while rotate single screen', error);
@@ -171,17 +172,17 @@ const Toolbar = ({
       <Button onClick={openDevTools} title="Open Devtools">
         <Icon icon="ic:round-code" />
       </Button>
-      <Button 
+      <Button
         onClick={rotate}
-        isActive={rotatedDevices[deviceID]?.inSingle}
+        isActive={devices[deviceID]?.rotate}
         title="Rotate This Device"
       >
         <Icon
           icon={
-            rotatedDevices[deviceID]?.inSingle
+            devices[deviceID]?.rotate
               ? 'mdi:phone-rotate-portrait'
               : 'mdi:phone-rotate-landscape'
-            }
+          }
         />
       </Button>
     </div>

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -52,26 +52,32 @@ interface ErrorState {
 }
 
 const Device = ({ isPrimary, device, id }: Props) => {
-  const rotatedDevices = useSelector(selectRotate);
+  const { devices, allRotated } = useSelector(selectRotate);
   let { height, width } = device;
-  if (rotatedDevices[id]?.rotate) {
-    const temp = width;
-    width = height;
-    height = temp;
+
+  if (devices[id]) {
+    const shouldRotate =
+      allRotated || (devices[id].inSingle && devices[id].rotate);
+
+    if (shouldRotate) {
+      const temp = width;
+      width = height;
+      height = temp;
+    }
   }
+
   const address = useSelector(selectAddress);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ErrorState | null>(null);
   const [screenshotInProgress, setScreenshotInProgess] =
     useState<boolean>(false);
-  const dispatch = useDispatch();
   const zoomfactor = useSelector(selectZoomFactor);
   const isInspecting = useSelector(selectIsInspecting);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const devtoolsOpenForWebviewId = useSelector(selectDevtoolsWebviewId);
-
   const dockPosition = useSelector(selectDockPosition);
   const ref = useRef<Electron.WebviewTag>(null);
+  const dispatch = useDispatch();
 
   const registerNavigationHandlers = useCallback(() => {
     webViewPubSub.subscribe(NAVIGATION_EVENTS.RELOAD, () => {

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -41,6 +41,7 @@ import Toolbar from './Toolbar';
 import { appendHistory } from './utils';
 
 interface Props {
+  id: string;
   device: IDevice;
   isPrimary: boolean;
 }
@@ -50,10 +51,10 @@ interface ErrorState {
   description: string;
 }
 
-const Device = ({ isPrimary, device }: Props) => {
-  const rotateDevice = useSelector(selectRotate);
+const Device = ({ isPrimary, device, id }: Props) => {
+  const rotatedDevices = useSelector(selectRotate);
   let { height, width } = device;
-  if (rotateDevice) {
+  if (rotatedDevices[id]?.rotate) {
     const temp = width;
     width = height;
     height = temp;
@@ -382,6 +383,7 @@ const Device = ({ isPrimary, device }: Props) => {
         {loading ? <Spinner spinnerHeight={24} /> : null}
       </div>
       <Toolbar
+        deviceID={id}
         webview={ref.current}
         device={device}
         setScreenshotInProgress={setScreenshotInProgess}

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
@@ -6,11 +7,14 @@ import {
   selectDockPosition,
   selectIsDevtoolsOpen,
 } from 'renderer/store/features/devtools';
-import { selectLayout, setRotate } from 'renderer/store/features/renderer';
+import {
+  selectLayout,
+  selectRotate,
+  setRotate,
+} from 'renderer/store/features/renderer';
 import { getDevicesMap } from 'common/deviceList';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
-import { useEffect } from 'react';
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -19,10 +23,26 @@ const Previewer = () => {
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
   const dispatch = useDispatch();
+  const rotatedDevices = useSelector(selectRotate);
 
   useEffect(() => {
-    dispatch(setRotate(devices.reduce((acc, device) => ({ ...acc, [device.name]: { inSingle: false, rotate: false } }), {})));
-  }, []);
+    const defaultDevicesRotation = {
+      ...rotatedDevices,
+      devices: devices.reduce(
+        (acc, device) => ({
+          ...acc,
+          [device.name]: {
+            inSingle: false,
+            rotate: false,
+          },
+        }),
+        {}
+      ),
+    };
+
+    dispatch(setRotate(defaultDevicesRotation));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSuite]);
 
   return (
     <div className="h-full">

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import { DOCK_POSITION, PREVIEW_LAYOUTS } from 'common/constants';
@@ -6,10 +6,11 @@ import {
   selectDockPosition,
   selectIsDevtoolsOpen,
 } from 'renderer/store/features/devtools';
-import { selectLayout } from 'renderer/store/features/renderer';
+import { selectLayout, setRotate } from 'renderer/store/features/renderer';
 import { getDevicesMap } from 'common/deviceList';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
+import { useEffect } from 'react';
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -17,6 +18,11 @@ const Previewer = () => {
   const dockPosition = useSelector(selectDockPosition);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setRotate(devices.reduce((acc, device) => ({ ...acc, [device.name]: { inSingle: false, rotate: false } }), {})));
+  }, []);
 
   return (
     <div className="h-full">
@@ -33,7 +39,12 @@ const Previewer = () => {
         >
           {devices.map((device, idx) => {
             return (
-              <Device key={device.name} device={device} isPrimary={idx === 0} />
+              <Device
+                id={device.name}
+                key={device.name}
+                device={device}
+                isPrimary={idx === 0}
+              />
             );
           })}
         </div>

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -12,11 +12,13 @@ import Button from '../Button';
 import AddressBar from './AddressBar';
 import ColorSchemeToggle from './ColorSchemeToggle';
 import { PreviewSuiteSelector } from './PreviewSuiteSelector';
+import { useState } from 'react';
 
 const Divider = () => <div className="h-6 w-px bg-gray-300 dark:bg-gray-700" />;
 
 const ToolBar = () => {
-  const rotateDevice = useSelector(selectRotate);
+  const rotatedDevices = useSelector(selectRotate);
+  const [ allDevicesRotated, setAllDevicesRotated ] = useState<boolean>(false);
   const isInspecting = useSelector(selectIsInspecting);
   const dispatch = useDispatch();
 
@@ -25,13 +27,27 @@ const ToolBar = () => {
       <NavigationControls />
       <AddressBar />
       <Button
-        onClick={() => dispatch(setRotate(!rotateDevice))}
-        isActive={rotateDevice}
+        onClick={async () => {
+          const obj = {...rotatedDevices};
+          
+          for (const deviceID of Object.keys(obj)) {
+            if (!(obj[deviceID].inSingle)) {
+              obj[deviceID] = {
+                ...obj[deviceID],
+                rotate: allDevicesRotated
+              };
+            }
+          }
+
+          dispatch(setRotate({...obj}));
+          setAllDevicesRotated(!allDevicesRotated);
+        }}
+        isActive={allDevicesRotated}
         title="Rotate Devices"
       >
         <Icon
           icon={
-            rotateDevice
+            allDevicesRotated
               ? 'mdi:phone-rotate-portrait'
               : 'mdi:phone-rotate-landscape'
           }

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -12,42 +12,30 @@ import Button from '../Button';
 import AddressBar from './AddressBar';
 import ColorSchemeToggle from './ColorSchemeToggle';
 import { PreviewSuiteSelector } from './PreviewSuiteSelector';
-import { useState } from 'react';
 
 const Divider = () => <div className="h-6 w-px bg-gray-300 dark:bg-gray-700" />;
 
 const ToolBar = () => {
-  const rotatedDevices = useSelector(selectRotate);
-  const [ allDevicesRotated, setAllDevicesRotated ] = useState<boolean>(false);
+  const { allRotated, ...rotatedDevices } = useSelector(selectRotate);
   const isInspecting = useSelector(selectIsInspecting);
   const dispatch = useDispatch();
+
+  const rotateDevices = () => {
+    dispatch(setRotate({ ...rotatedDevices, allRotated: !allRotated }));
+  };
 
   return (
     <div className="flex items-center justify-between gap-2">
       <NavigationControls />
       <AddressBar />
       <Button
-        onClick={async () => {
-          const obj = {...rotatedDevices};
-          
-          for (const deviceID of Object.keys(obj)) {
-            if (!(obj[deviceID].inSingle)) {
-              obj[deviceID] = {
-                ...obj[deviceID],
-                rotate: allDevicesRotated
-              };
-            }
-          }
-
-          dispatch(setRotate({...obj}));
-          setAllDevicesRotated(!allDevicesRotated);
-        }}
-        isActive={allDevicesRotated}
+        onClick={rotateDevices}
+        isActive={allRotated}
         title="Rotate Devices"
       >
         <Icon
           icon={
-            allDevicesRotated
+            allRotated
               ? 'mdi:phone-rotate-portrait'
               : 'mdi:phone-rotate-landscape'
           }

--- a/desktop-app/src/renderer/store/features/renderer/index.ts
+++ b/desktop-app/src/renderer/store/features/renderer/index.ts
@@ -3,10 +3,12 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { PreviewLayout } from 'common/constants';
 import type { RootState } from '../..';
 
+type IRotatedDevices = { [key: string]: { inSingle: boolean, rotate: boolean } };
+
 export interface RendererState {
   address: string;
   zoomFactor: number;
-  rotate: boolean;
+  rotatedDevices: IRotatedDevices;
   isInspecting: boolean | undefined;
   layout: PreviewLayout;
 }
@@ -27,7 +29,7 @@ const urlFromQueryParam = () => {
 const initialState: RendererState = {
   address: urlFromQueryParam() ?? window.electron.store.get('homepage'),
   zoomFactor: zoomSteps[window.electron.store.get('renderer.zoomStepIndex')],
-  rotate: false,
+  rotatedDevices: {},
   isInspecting: undefined,
   layout: window.electron.store.get('ui.previewLayout'),
 };
@@ -57,8 +59,8 @@ export const rendererSlice = createSlice({
         window.electron.store.set('renderer.zoomStepIndex', newIndex);
       }
     },
-    setRotate: (state, action: PayloadAction<boolean>) => {
-      state.rotate = action.payload;
+    setRotate: (state, action: PayloadAction<IRotatedDevices>) => {
+      state.rotatedDevices = action.payload;
     },
     setIsInspecting: (state, action: PayloadAction<boolean>) => {
       state.isInspecting = action.payload;
@@ -82,7 +84,7 @@ export const {
 
 export const selectZoomFactor = (state: RootState) => state.renderer.zoomFactor;
 export const selectAddress = (state: RootState) => state.renderer.address;
-export const selectRotate = (state: RootState) => state.renderer.rotate;
+export const selectRotate = (state: RootState) => state.renderer.rotatedDevices;
 export const selectIsInspecting = (state: RootState) =>
   state.renderer.isInspecting;
 export const selectLayout = (state: RootState) => state.renderer.layout;

--- a/desktop-app/src/renderer/store/features/renderer/index.ts
+++ b/desktop-app/src/renderer/store/features/renderer/index.ts
@@ -3,12 +3,15 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { PreviewLayout } from 'common/constants';
 import type { RootState } from '../..';
 
-type IRotatedDevices = { [key: string]: { inSingle: boolean, rotate: boolean } };
+type IRotatedDevices = {
+  [key: string]: { inSingle: boolean; rotate: boolean };
+};
+type IDevicesOrientation = { allRotated: boolean; devices: IRotatedDevices };
 
 export interface RendererState {
   address: string;
   zoomFactor: number;
-  rotatedDevices: IRotatedDevices;
+  rotatedDevices: IDevicesOrientation;
   isInspecting: boolean | undefined;
   layout: PreviewLayout;
 }
@@ -29,7 +32,7 @@ const urlFromQueryParam = () => {
 const initialState: RendererState = {
   address: urlFromQueryParam() ?? window.electron.store.get('homepage'),
   zoomFactor: zoomSteps[window.electron.store.get('renderer.zoomStepIndex')],
-  rotatedDevices: {},
+  rotatedDevices: { allRotated: false, devices: {} },
   isInspecting: undefined,
   layout: window.electron.store.get('ui.previewLayout'),
 };
@@ -59,7 +62,7 @@ export const rendererSlice = createSlice({
         window.electron.store.set('renderer.zoomStepIndex', newIndex);
       }
     },
-    setRotate: (state, action: PayloadAction<IRotatedDevices>) => {
+    setRotate: (state, action: PayloadAction<IDevicesOrientation>) => {
       state.rotatedDevices = action.payload;
     },
     setIsInspecting: (state, action: PayloadAction<boolean>) => {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Reference to Issue #897

### ℹ️ About the PR

The main rotation button are with the same behavior. But each device has a button that control their own status and when activated, lock the interaction with the main rotation button.

All the screens were controlled by one boolean variable in redux store. Now that variable is an object with the [following interface](https://github.com/WayneRocha/responsively-app/blob/main/desktop-app/src/renderer/store/features/renderer/index.ts#L9). It has one boolean property for main button, and other for each individual device status, keyed by the _name_.

### 🖼️ Testing Scenarios / Screenshots

![image](https://user-images.githubusercontent.com/62760711/236391639-d37ce091-1640-4fc3-ba2f-1067ea61f26d.png)
![image](https://user-images.githubusercontent.com/62760711/236391697-d1d367
![2023-05-05 03-41-18](https://user-images.githubusercontent.com/62760711/236392348-f484eb5d-f075-4f27-98d5-86d3b417353b.gif)
44-8893-4b84-b8ef-7f2c5d277f18.png)

