### PR TITLE
Fix browser-sync issue related to Content Security Policy (CSP)

### DIFF
--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -117,7 +117,7 @@ const createWindow = async () => {
   // Add BROWSER_SYNC_HOST to the allowed Content-Security-Policy origins
   mainWindow.webContents.session.webRequest.onHeadersReceived(
     async (details, callback) => {
-      if (details.responseHeaders['content-security-policy']) {
+      if (details.responseHeaders?.['content-security-policy']) {
         let cspHeader = details.responseHeaders['content-security-policy'][0];
 
         cspHeader = cspHeader.replace(

--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -114,6 +114,43 @@ const createWindow = async () => {
   initHttpBasicAuthHandlers(mainWindow);
   const webPermissionHandlers = WebPermissionHandlers(mainWindow);
 
+  // Add BROWSER_SYNC_HOST to the allowed Content-Security-Policy origins
+  mainWindow.webContents.session.webRequest.onHeadersReceived(
+    async (details, callback) => {
+      if (details.responseHeaders['content-security-policy']) {
+        let cspHeader = details.responseHeaders['content-security-policy'][0];
+
+        cspHeader = cspHeader.replace(
+          'default-src',
+          `default-src ${BROWSER_SYNC_HOST}`
+        );
+        cspHeader = cspHeader.replace(
+          'script-src',
+          `script-src ${BROWSER_SYNC_HOST}`
+        );
+        cspHeader = cspHeader.replace(
+          'script-src-elem',
+          `script-src-elem ${BROWSER_SYNC_HOST}`
+        );
+        cspHeader = cspHeader.replace(
+          'connect-src',
+          `connect-src ${BROWSER_SYNC_HOST} wss://${BROWSER_SYNC_HOST} ws://${BROWSER_SYNC_HOST}`
+        );
+        cspHeader = cspHeader.replace(
+          'child-src',
+          `child-src ${BROWSER_SYNC_HOST}`
+        );
+        cspHeader = cspHeader.replace(
+          'worker-src',
+          `worker-src ${BROWSER_SYNC_HOST}`
+        ); // Required when/if the browser-sync script is eventually relocated to a web worker
+
+        details.responseHeaders['content-security-policy'][0] = cspHeader;
+      }
+      callback({ responseHeaders: details.responseHeaders });
+    }
+  );
+
   mainWindow.loadURL(
     `${resolveHtmlPath('index.html')}?urlToOpen=${encodeURI(
       urlToOpen ?? 'undefined'


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Resolves issues with browser-sync such as scrolling, for websites with strict Content Security Policy (CSP) rules that prevent the injected browser-sync script from loading.

Fixes: #710 and #860 

### ℹ️ About the PR

Injects the BROWSER_SYNC_HOST to the allowed Content-Security-Policy origins header

### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->
