### PR TITLE
Feature merge all screenshots

### DIFF
--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -117,6 +117,7 @@
     "electron-store": "^8.0.2",
     "electron-updater": "^5.2.3",
     "emitter": "^0.0.5",
+    "jpeg-js": "^0.4.4",
     "mousetrap": "^1.6.5",
     "os": "^0.1.2",
     "postcss": "^8.4.14",

--- a/desktop-app/src/common/image/bitmap.ts
+++ b/desktop-app/src/common/image/bitmap.ts
@@ -1,0 +1,261 @@
+/**
+ * Bitmap class to create image bitmaps
+ */
+import { WriteStream, createWriteStream } from 'fs';
+import jpeg from 'jpeg-js';
+
+interface RGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+interface FileOptions {
+  quality: number;
+  type: ImageType;
+}
+
+export type COLOR = RGBA;
+
+export interface BitmapData {
+  width?: number;
+  height?: number;
+  data?: ArrayBuffer;
+  color?: COLOR;
+}
+
+export enum FileType {
+  PNG = 'png',
+  JPEG = 'jpeg',
+  JPG = 'jpg',
+}
+
+export enum ImageType {
+  PNG = 1,
+  JPEG = 2,
+}
+
+export const TRANSPARENT_BLACK = { r: 0, g: 0, b: 0, a: 0 };
+
+export class Bitmap {
+  private width!: number;
+
+  private height!: number;
+
+  private data!: Buffer;
+
+  constructor(bitmapData: BitmapData) {
+    this.initData(bitmapData);
+  }
+
+  get Height() {
+    return this.height;
+  }
+
+  get Width() {
+    return this.width;
+  }
+
+  /**
+   * JPEG data buffer
+   *
+   * @param data JPEG data
+   */
+  public decodeBuffer(data: Buffer) {
+    const { width, height, data: bufferData } = jpeg.decode(data);
+    this.width = width;
+    this.height = height;
+    this.data = bufferData;
+  }
+
+  public drawImage(
+    imageBuffer: Buffer,
+    startPosition: number,
+    imgWidth: number
+  ) {
+    let sourceStart = 0;
+    let sourceEnd = imgWidth;
+    let targetStart = startPosition;
+    const { length } = imageBuffer;
+    const jump = this.width * 4;
+    for (let i = 0; i < length; i += imgWidth) {
+      imageBuffer.copy(this.data, targetStart, sourceStart, sourceEnd);
+      targetStart += jump;
+      sourceStart = sourceEnd;
+      sourceEnd += imgWidth;
+    }
+  }
+
+  public jpecEncode(quality: number): jpeg.BufferRet {
+    return jpeg.encode(
+      { data: this.data, width: this.width, height: this.height },
+      quality
+    );
+  }
+
+  public write(stream: WriteStream, options: FileOptions): Promise<string> {
+    return new Promise((resolve, reject) => {
+      try {
+        stream.on('finish', () => {
+          resolve('done');
+        });
+        stream.on('error', (error) => {
+          reject(error);
+        });
+        switch (options.type) {
+          case ImageType.JPEG:
+            stream.write(
+              jpeg.encode(
+                { data: this.data, width: this.width, height: this.height },
+                options.quality || 90
+              ).data
+            );
+            stream.end();
+            break;
+          case ImageType.PNG:
+            break;
+          default:
+            break;
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  public async writeFile(filePath: string, quality: number) {
+    const options = this.parseFileOptions(filePath, quality);
+    const stream = createWriteStream(filePath);
+    await this.write(stream, options);
+  }
+
+  private parseFileOptions(fileName: string, quality: number): FileOptions {
+    const fileType = this.deduceFileType(fileName);
+    const fileOptions: FileOptions = {
+      quality: quality || 100,
+      type: fileType,
+    };
+    return fileOptions;
+  }
+
+  /**
+   * @param fileName {string} name of the file
+   * @returns deduces file type from the file name
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private deduceFileType(fileName: string): ImageType {
+    // check if valid fileName
+    if (!fileName) {
+      throw new Error('Invalid file name');
+    }
+
+    const fileExtension = fileName.split('.').pop();
+    switch (fileExtension) {
+      case FileType.JPEG:
+        return ImageType.JPEG;
+      case FileType.JPG:
+        return ImageType.JPEG;
+      case FileType.PNG:
+        return ImageType.PNG;
+      default:
+        break;
+    }
+    // if non of extensions mathces
+    throw new Error('Invalid file type');
+  }
+
+  /**
+   * Creates a bitmap object for image manipulation
+   *
+   * @param bitmapOptions initial bitmap data
+   */
+  private initData(bitmapOptions: BitmapData) {
+    const { width, height, data } = bitmapOptions;
+
+    if (width && height) {
+      this.width = width;
+      this.height = height;
+      this.data = data ? Buffer.from(data) : Buffer.alloc(width * height * 4);
+      this.fillData(
+        bitmapOptions.color || TRANSPARENT_BLACK,
+        0,
+        0,
+        width,
+        height
+      );
+    }
+  }
+
+  /**
+   * fills a color in the bitmap
+   *
+   * @param color color to be filled in the bitmap
+   * @param left position of the left side of the rectangle from where the fill starts
+   * @param top position of the top side of the rectangle from where the fill starts
+   * @param width upto which width the fill should happen
+   * @param height upto which height the fill should happen
+   */
+  private fillData(
+    color: COLOR,
+    left: number,
+    top: number,
+    width: number,
+    height: number
+  ) {
+    const leftPosition = left || 0;
+    const topPosition = top || 0;
+    const finalWidth = width || this.width - left;
+    const finalHeight = height || this.height - top;
+
+    // validate left and top
+    if (leftPosition < 0 || leftPosition > this.width) {
+      throw new Error('Invalid left position');
+    }
+
+    if (topPosition < 0 || topPosition > this.height) {
+      throw new Error('Invalid top position');
+    }
+
+    // validate width and height
+    if (finalWidth < 0 || finalWidth > this.width) {
+      throw new Error('Invalid width');
+    }
+
+    if (finalHeight < 0 || finalHeight > this.height) {
+      throw new Error('Invalid height');
+    }
+
+    const finalColor = color || TRANSPARENT_BLACK;
+    const { r, g, b, a } = finalColor;
+    const buf = this.data;
+    const bottomPosition = topPosition + finalHeight;
+    const rightPosition = leftPosition + finalWidth;
+
+    // step 1: fille first scanline
+    const positionFromBufferStarts =
+      (topPosition * this.width + leftPosition) * 4;
+    let currentPosition = positionFromBufferStarts;
+    for (let i = leftPosition; i < rightPosition; i += 1) {
+      buf[currentPosition] = r;
+      buf[currentPosition + 1] = g;
+      buf[currentPosition + 2] = b;
+      buf[currentPosition + 3] = a;
+      currentPosition += 4;
+    }
+
+    // copy that line into other places
+    const positionFromBufferEnds = currentPosition;
+    let positionFromCopyShouldstart = positionFromBufferEnds;
+    for (let i = topPosition + 1; i < bottomPosition; i += 1) {
+      buf.copy(
+        buf,
+        positionFromCopyShouldstart,
+        positionFromBufferStarts,
+        positionFromBufferEnds
+      );
+      positionFromCopyShouldstart +=
+        positionFromBufferEnds - positionFromBufferStarts;
+    }
+  }
+}

--- a/desktop-app/src/common/image/jpeg.ts
+++ b/desktop-app/src/common/image/jpeg.ts
@@ -1,0 +1,17 @@
+import jpeg from 'jpeg-js';
+
+export interface JpegData {
+  data: Buffer;
+  width: number;
+  height: number;
+}
+
+export class JpegUtils {
+  public static decode(data: Buffer): JpegData {
+    return jpeg.decode(data);
+  }
+
+  public static encode(data: JpegData, quality: number): Buffer {
+    return jpeg.encode(data, quality).data;
+  }
+}

--- a/desktop-app/src/common/image/merge.ts
+++ b/desktop-app/src/common/image/merge.ts
@@ -1,0 +1,50 @@
+import { JpegData, JpegUtils } from './jpeg';
+import { Bitmap } from './bitmap';
+
+export class MergeImages {
+  images: Buffer[];
+
+  constructor(images: Buffer[]) {
+    this.images = images;
+  }
+
+  public merge(): Bitmap {
+    const decodedImages = this.decodeImages();
+    const finalHeight = decodedImages.reduce((prevVal, currVal) => {
+      return Math.max(prevVal, currVal.height);
+    }, 0);
+    const finalWidth = decodedImages.reduce((prevVal, currVal) => {
+      return prevVal + currVal.width + 20;
+    }, 20);
+    const offsets: number[] = [];
+    decodedImages.forEach((image, index) => {
+      if (index === 0) {
+        offsets.push(0);
+      } else {
+        offsets.push(offsets[index - 1] + decodedImages[index - 1].width * 4);
+      }
+    });
+    const sharedImageBuffer = new ArrayBuffer(finalHeight * finalWidth * 4);
+    const mergedBitmap = new Bitmap({
+      data: sharedImageBuffer,
+      width: finalWidth,
+      height: finalHeight,
+    });
+    for (let i = 0; i < decodedImages.length; i += 1) {
+      const decodedImage = decodedImages[i];
+      const { data, width } = decodedImage;
+
+      mergedBitmap.drawImage(data, offsets[i] + i * 20 * 4, width * 4);
+    }
+
+    return mergedBitmap;
+  }
+
+  private decodeImages(): JpegData[] {
+    const decodedImages = this.images.map((image) => {
+      return JpegUtils.decode(image);
+    });
+
+    return decodedImages;
+  }
+}

--- a/desktop-app/src/common/image/merge.ts
+++ b/desktop-app/src/common/image/merge.ts
@@ -24,7 +24,9 @@ export class MergeImages {
         offsets.push(offsets[index - 1] + decodedImages[index - 1].width * 4);
       }
     });
-    const sharedImageBuffer = new ArrayBuffer(finalHeight * finalWidth * 4);
+    const sharedImageBuffer = new SharedArrayBuffer(
+      finalHeight * finalWidth * 4
+    );
     const mergedBitmap = new Bitmap({
       data: sharedImageBuffer,
       width: finalWidth,

--- a/desktop-app/src/renderer/components/ModalLoader/captureAllScreens.tsx
+++ b/desktop-app/src/renderer/components/ModalLoader/captureAllScreens.tsx
@@ -61,7 +61,6 @@ const CaptureAllScreens = ({ isOpen, onClose, title, formData }: Props) => {
                   id="save-separatly"
                   name="Save each Image seperatly"
                   value="save_seperatly"
-                  checked={captureEachImage}
                   onChange={(e) => setCaptureEachImage(e.target.checked)}
                 />
               </div>
@@ -71,7 +70,6 @@ const CaptureAllScreens = ({ isOpen, onClose, title, formData }: Props) => {
                   type="checkbox"
                   id="merge-images"
                   name="Merge Images"
-                  checked={mergeImages}
                   onChange={(e) => setMergeImage(e.target.checked)}
                 />
               </div>
@@ -82,7 +80,6 @@ const CaptureAllScreens = ({ isOpen, onClose, title, formData }: Props) => {
                 type="text"
                 disabled={!mergeImages}
                 placeholder="Enter prefix..."
-                value={prefix}
                 onChange={(e) => setPrefix(e.target.value)}
               />
               <p className="text-sm">Prefix needed for merging images</p>

--- a/desktop-app/src/renderer/components/ModalLoader/captureAllScreens.tsx
+++ b/desktop-app/src/renderer/components/ModalLoader/captureAllScreens.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import { FormEvent, useEffect, useState } from 'react';
+import Button from '../Button';
+import Input from '../Input';
+import Modal from '../Modal';
+
+interface FormData {
+  captureEachImage: boolean;
+  mergeImages: boolean;
+  prefix: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  formData: (data: FormData) => void;
+  title: JSX.Element | string;
+}
+
+const CaptureAllScreens = ({ isOpen, onClose, title, formData }: Props) => {
+  const [captureEachImage, setCaptureEachImage] = useState(false);
+  const [mergeImages, setMergeImage] = useState(false);
+  const [prefix, setPrefix] = useState<string>('');
+  const [isFormValid, setFormValidity] = useState(false);
+
+  const captureImages = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    formData({ captureEachImage, mergeImages, prefix });
+  };
+
+  const validateInput = () => {
+    if (captureEachImage || mergeImages) {
+      if (mergeImages && prefix && prefix.trim() !== '') {
+        setFormValidity(true);
+      } else if (captureEachImage && !mergeImages) {
+        setFormValidity(true);
+      } else {
+        setFormValidity(false);
+      }
+    } else {
+      setFormValidity(false);
+    }
+  };
+
+  useEffect(() => {
+    validateInput();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mergeImages, captureEachImage, prefix]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <div>
+        <div className="h-px w-full bg-black" />
+        <form onSubmit={(e) => captureImages(e)}>
+          <div className="flex flex-col">
+            <div className="flex flex-row">
+              <div className="pt-5 pr-5 pb-5">
+                <Input
+                  type="checkbox"
+                  label="Save each image seperatly"
+                  id="save-separatly"
+                  name="Save each Image seperatly"
+                  value="save_seperatly"
+                  checked={captureEachImage}
+                  onChange={(e) => setCaptureEachImage(e.target.checked)}
+                />
+              </div>
+              <div className="pl-5 pt-5 pb-5">
+                <Input
+                  label="Merge images"
+                  type="checkbox"
+                  id="merge-images"
+                  name="Merge Images"
+                  checked={mergeImages}
+                  onChange={(e) => setMergeImage(e.target.checked)}
+                />
+              </div>
+            </div>
+            <div>
+              <Input
+                label="Prefix for merged Image"
+                type="text"
+                disabled={!mergeImages}
+                placeholder="Enter prefix..."
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+              />
+              <p className="text-sm">Prefix needed for merging images</p>
+            </div>
+            <div className="flex justify-end pt-5">
+              <Button
+                type="submit"
+                className="bg-blue-500 px-2 text-white hover:bg-blue-700 disabled:bg-gray-500 dark:hover:bg-blue-600"
+                onClick={() => {}}
+                disabled={!isFormValid}
+              >
+                Capture
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};
+
+export default CaptureAllScreens;

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -8,11 +8,12 @@ import {
   setRotate,
 } from 'renderer/store/features/renderer';
 import { Icon } from '@iconify/react';
-import { ScreenshotAllArgs } from 'main/screenshot';
+import { ScreenshotAllArgs, FormData, EventData } from 'main/screenshot';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import WebPage from 'main/screenshot/webpage';
 import { getDevicesMap } from 'common/deviceList';
 import { updateWebViewHeightAndScale } from 'common/webViewUtils';
+import { useState } from 'react';
 import NavigationControls from './NavigationControls';
 import Menu from './Menu';
 import Button from '../Button';
@@ -20,6 +21,7 @@ import AddressBar from './AddressBar';
 import ColorSchemeToggle from './ColorSchemeToggle';
 import ModalLoader from '../ModalLoader';
 import { PreviewSuiteSelector } from './PreviewSuiteSelector';
+import CaptureAllScreens from '../ModalLoader/captureAllScreens';
 
 const Divider = () => <div className="h-6 w-px bg-gray-300 dark:bg-gray-700" />;
 
@@ -28,9 +30,14 @@ const ToolBar = () => {
   const isInspecting = useSelector(selectIsInspecting);
   const isCapturingScreenshot = useSelector(selectIsCapturingScreenshot);
   const activeSuite = useSelector(selectActiveSuite);
+  const [showDiaglogue, setShowDialogue] = useState(false);
   const dispatch = useDispatch();
 
-  const screenshotCaptureHandler = async () => {
+  const screenshotCaptureHandler = async (
+    captureEachScreen: boolean,
+    mergeImage: boolean,
+    prefix = ''
+  ) => {
     dispatch(setIsCapturingScreenshot(true));
     const webViews: NodeListOf<Electron.WebviewTag> =
       document.querySelectorAll('webView');
@@ -53,12 +60,17 @@ const ToolBar = () => {
         });
       }
     });
+    const eventData: EventData = {
+      captureEachImage: captureEachScreen,
+      mergeImages: mergeImage,
+      prefix,
+      screens,
+    };
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    await window.electron.ipcRenderer.invoke<Array<ScreenshotAllArgs>, any>(
+    await window.electron.ipcRenderer.invoke<EventData, any>(
       'screenshot:All',
-      screens
+      eventData
     );
-
     // reset webviews to original size
     webViews.forEach((webview) => {
       const screent = screens.find((s) => s.device.name === webview.id);
@@ -69,6 +81,20 @@ const ToolBar = () => {
     });
 
     dispatch(setIsCapturingScreenshot(false));
+  };
+
+  const captureAllScreensFormData = async (data: FormData) => {
+    setShowDialogue(false);
+    await screenshotCaptureHandler(
+      data.captureEachImage,
+      data.mergeImages,
+      data.prefix
+    );
+  };
+
+  const captureAllScreens = async () => {
+    // TODO: take screen capture
+    setShowDialogue(true);
   };
 
   const handleClose = () => {
@@ -100,7 +126,7 @@ const ToolBar = () => {
         <Icon icon="lucide:inspect" />
       </Button>
       <Button
-        onClick={screenshotCaptureHandler}
+        onClick={captureAllScreens}
         isActive={isCapturingScreenshot}
         title="Screenshot All WebViews"
       >
@@ -110,6 +136,12 @@ const ToolBar = () => {
       <Divider />
       <PreviewSuiteSelector />
       <Menu />
+      <CaptureAllScreens
+        isOpen={showDiaglogue}
+        onClose={() => setShowDialogue(false)}
+        title="Capture All Pages"
+        formData={captureAllScreensFormData}
+      />
       <ModalLoader
         isOpen={isCapturingScreenshot}
         onClose={handleClose}


### PR DESCRIPTION
# ✨ Pull Request
Add merge screenshot functionality to existing capture all screen screen function

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->
Fixes #917 

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->
Adds merge all screens using buffer data merge. I am using `jpeg-js` library for proper decoding of data to jpeg images.
The merge on nodejs side should give us some performance benefits like not blocking main event loop. Also there is prefix input box which can be used to enter the prefix to be added for merged image while saving to fs. User has option to merge all the screens or not, below screenshot should give all clarity on options.
<img width="418" alt="image" src="https://github.com/responsively-org/responsively-app/assets/17452039/08968349-88fb-4270-a6df-8280dc956523">


### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->
- Save each image separately option allows each webview to be captured and saved as jpeg image.
- Merge images option allows all webviews to be captured, merged and saved as jpeg image.
- When user chooses merge images options he must enter prefix (prefix to the merged jpeg image) otherwise not needed.
![test 4-1684071131934](https://github.com/responsively-org/responsively-app/assets/17452039/8e3259c3-3054-4257-b773-7257da1f6d9b)


