### PR TITLE
added feat: enable/disable individual layout view

### DIFF
--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -129,6 +129,7 @@
     "react-markdown": "^8.0.7",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.3.0",
+    "react-tabs": "^6.0.1",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
     "replace": "^1.2.1",

--- a/desktop-app/src/common/constants.ts
+++ b/desktop-app/src/common/constants.ts
@@ -9,6 +9,7 @@ export const DOCK_POSITION = {
 export const PREVIEW_LAYOUTS = {
   COLUMN: 'COLUMN',
   FLEX: 'FLEX',
+  INDIVIDUAL: 'INDIVIDUAL',
 } as const;
 
 export type PreviewLayout =

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -15,6 +15,8 @@ interface Props {
   setScreenshotInProgress: (value: boolean) => void;
   openDevTools: () => void;
   onRotate: (state: boolean) => void;
+  onIndividualLayoutHandler: (device: Device) => void;
+  isIndividualLayout: boolean;
 }
 
 const Toolbar = ({
@@ -23,6 +25,8 @@ const Toolbar = ({
   setScreenshotInProgress,
   openDevTools,
   onRotate,
+  onIndividualLayoutHandler,
+  isIndividualLayout,
 }: Props) => {
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, { volume: 0.5 });
@@ -158,6 +162,18 @@ const Toolbar = ({
         <Icon
           icon={
             rotated ? 'mdi:phone-rotate-portrait' : 'mdi:phone-rotate-landscape'
+          }
+        />
+      </Button>
+      <Button
+        onClick={() => onIndividualLayoutHandler(device)}
+        title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}
+      >
+        <Icon
+          icon={
+            isIndividualLayout
+              ? 'ic:twotone-zoom-in-map'
+              : 'ic:twotone-zoom-out-map'
           }
         />
       </Button>

--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Tab, Tabs, TabList } from 'react-tabs';
+import { Icon } from '@iconify/react';
+import cx from 'classnames';
+import { setLayout } from 'renderer/store/features/renderer';
+import { PREVIEW_LAYOUTS } from 'common/constants';
+import { Device as IDevice } from 'common/deviceList';
+import './styles.css';
+
+interface Props {
+  individualDevice: IDevice;
+  setIndividualDevice: (device: IDevice) => void;
+  devices: IDevice[];
+}
+
+const IndividualLayoutToolbar = ({
+  individualDevice,
+  setIndividualDevice,
+  devices,
+}: Props) => {
+  const dispatch = useDispatch();
+  const [activeTab, setActiveTab] = useState(0);
+
+  const onTabClick = (newTabIndex: number) => {
+    setActiveTab(newTabIndex);
+    setIndividualDevice(devices[newTabIndex]);
+  };
+
+  const isActive = (idx: number) => activeTab === idx;
+  const handleCloseBtn = () => dispatch(setLayout(PREVIEW_LAYOUTS.COLUMN));
+
+  useEffect(() => {
+    const activeTabIndex = devices.findIndex(
+      (device) => device.id === individualDevice.id
+    );
+    setActiveTab(activeTabIndex);
+  }, [individualDevice, devices]);
+
+  return (
+    <div className="my-4 ml-12 mr-4 flex justify-between">
+      <Tabs
+        onSelect={onTabClick}
+        selectedIndex={activeTab}
+        className={cx('react-tabs flex')}
+      >
+        <TabList
+          className={cx(
+            'custom-scrollbar flex gap-1  overflow-x-auto border-b border-slate-400/60 dark:border-white'
+          )}
+        >
+          {devices.map((device, idx) => (
+            <Tab
+              className={cx(
+                'border-1 bottom-auto flex flex-shrink-0 cursor-pointer items-center rounded-t-md border-gray-300 px-4',
+                {
+                  'bg-slate-400/60': isActive(idx),
+                  'dark:bg-slate-100/90': isActive(idx),
+                  'text-light-normal': isActive(idx),
+                }
+              )}
+              key={device.id}
+            >
+              {device.name}
+            </Tab>
+          ))}
+        </TabList>
+      </Tabs>
+      <div className="relative top-1 ml-6">
+        <Icon
+          icon="carbon:close-outline"
+          className="cursor-pointer"
+          height={20}
+          onClick={handleCloseBtn}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default IndividualLayoutToolbar;

--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/styles.css
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/styles.css
@@ -1,0 +1,26 @@
+.custom-scrollbar::-webkit-scrollbar,
+.custom-scrollbar::-webkit-scrollbar:hover,
+.dark .custom-scrollbar::-webkit-scrollbar,
+.dark .custom-scrollbar::-webkit-scrollbar:hover {
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb,
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(148, 163, 184, 0.7);
+}
+
+.dark .custom-scrollbar::-webkit-scrollbar {
+  background-color: rgba(148, 163, 184, 0.6);
+}
+
+.dark .custom-scrollbar::-webkit-scrollbar-thumb,
+.dark .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(241, 245, 249, 0.8);
+}

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -7,7 +7,8 @@ import {
   selectIsDevtoolsOpen,
 } from 'renderer/store/features/devtools';
 import { selectLayout } from 'renderer/store/features/renderer';
-import { getDevicesMap } from 'common/deviceList';
+import { getDevicesMap, Device as IDevice } from 'common/deviceList';
+import { useState } from 'react';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
 
@@ -17,23 +18,51 @@ const Previewer = () => {
   const dockPosition = useSelector(selectDockPosition);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
+  const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
+
+  const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
   return (
     <div className="h-full">
       <div
-        className={cx('flex h-full justify-between', {
-          'flex-col': dockPosition === DOCK_POSITION.BOTTOM,
-          'flex-row': dockPosition === DOCK_POSITION.RIGHT,
-        })}
+        className={cx(
+          'flex h-full',
+          {
+            'flex-col': dockPosition === DOCK_POSITION.BOTTOM,
+            'flex-row': dockPosition === DOCK_POSITION.RIGHT,
+          },
+          {
+            'justify-between': !isIndividualLayout,
+            'justify-center': isIndividualLayout,
+          }
+        )}
       >
         <div
           className={cx('flex h-full gap-4 overflow-auto p-4', {
             'flex-wrap': layout === PREVIEW_LAYOUTS.FLEX,
           })}
         >
-          {devices.map((device, idx) => (
-            <Device key={device.id} device={device} isPrimary={idx === 0} />
-          ))}
+          {isIndividualLayout ? (
+            <>
+              <Device
+                key={individualDevice.id}
+                device={individualDevice}
+                isPrimary
+                setIndividualDevice={setIndividualDevice}
+              />
+            </>
+          ) : (
+            <>
+              {devices.map((device, idx) => (
+                <Device
+                  key={device.id}
+                  device={device}
+                  isPrimary={idx === 0}
+                  setIndividualDevice={setIndividualDevice}
+                />
+              ))}
+            </>
+          )}
         </div>
         {isDevtoolsOpen && dockPosition !== DOCK_POSITION.UNDOCKED ? (
           <DevtoolsResizer />

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -6,11 +6,12 @@ import {
   selectDockPosition,
   selectIsDevtoolsOpen,
 } from 'renderer/store/features/devtools';
-import { selectLayout } from 'renderer/store/features/renderer';
 import { getDevicesMap, Device as IDevice } from 'common/deviceList';
 import { useState } from 'react';
+import { selectLayout } from 'renderer/store/features/renderer';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
+import IndividualLayoutToolbar from './IndividualLayoutToolBar';
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -24,22 +25,24 @@ const Previewer = () => {
 
   return (
     <div className="h-full">
+      {isIndividualLayout && (
+        <IndividualLayoutToolbar
+          individualDevice={individualDevice}
+          setIndividualDevice={setIndividualDevice}
+          devices={devices}
+        />
+      )}
       <div
-        className={cx(
-          'flex h-full',
-          {
-            'flex-col': dockPosition === DOCK_POSITION.BOTTOM,
-            'flex-row': dockPosition === DOCK_POSITION.RIGHT,
-          },
-          {
-            'justify-between': !isIndividualLayout,
-            'justify-center': isIndividualLayout,
-          }
-        )}
+        className={cx('flex h-full', {
+          'flex-col': dockPosition === DOCK_POSITION.BOTTOM,
+          'flex-row': dockPosition === DOCK_POSITION.RIGHT,
+          'justify-between': !isIndividualLayout,
+        })}
       >
         <div
           className={cx('flex h-full gap-4 overflow-auto p-4', {
             'flex-wrap': layout === PREVIEW_LAYOUTS.FLEX,
+            'justify-center': isIndividualLayout,
           })}
         >
           {isIndividualLayout ? (


### PR DESCRIPTION
# ✨ Pull Request
### Introducing Individual Layout View Button and Device Toggle in Toolbar

### 📓 Referenced Issue
Fixes: #883

### ℹ️ About the PR
As per the issue, there was a need to have an individual layout view. I have addressed this by adding a button in the Toolbar section of the Device. Users can now click this button to enable and disable individual layout view.

I have added the following changes:

1. Added a button on the device toolbar that allows users to enable/disable to an individual layout mode.
2. Implemented a new toolbar for the individual layout mode, enabling users to toggle between multiple devices on the screen.
3. Included a close button for users to exit the individual layout view.
4. Implemented a custom scrollbar to ensure unobstructed visibility of the text.

Additionally, I fixed a breaking change in the handler 'disable-default-window-open-handler' (line 287, Device/index.js) that caused issues when users repeatedly clicked the individual layout button.

I have thoroughly tested the changes and have attached screenshots below. Please let me know if there are any additional requirements that can be addressed.

### 🖼️ Testing Scenarios / Screenshots
<img width="416" alt="Screenshot 2023-05-28 at 5 53 17 PM" src="https://github.com/responsively-org/responsively-app/assets/59393936/6846e48d-7011-4dcb-bbde-f3e7488d5f09">
<img width="1438" alt="Screenshot 2023-05-28 at 5 52 16 PM" src="https://github.com/responsively-org/responsively-app/assets/59393936/afcd7617-abe5-40d1-9d56-016939d07ed0">
<img width="1440" alt="Screenshot 2023-05-28 at 5 52 33 PM" src="https://github.com/responsively-org/responsively-app/assets/59393936/626bf22b-ec28-4630-a505-d34a5b42031c">
<img width="1440" alt="Screenshot 2023-05-28 at 5 52 52 PM" src="https://github.com/responsively-org/responsively-app/assets/59393936/2fd6cdce-cde0-4044-ba0f-b2f089d1c407">
<img width="1440" alt="Screenshot 2023-05-28 at 5 54 08 PM" src="https://github.com/responsively-org/responsively-app/assets/59393936/721a974a-f3d2-4ba9-a85d-6b196940046e">

I tested the following scenarios to validate the changes:

- Clicked the individual layout button to enable and disable the view in the flex & column layout modes
- Ensured that the breaking change no longer occurs when repeatedly clicking the button
- Toggling between multiple devices and ensuring nothing breaks
- Toggling between dark and light theme modes
- Verifying the functionality of the custom scrollbar to ensure there is no obstruction to the texts
- Verified the expected behavior of the layout view