### PR TITLE
add sponsor button in release note popup #940

### DIFF
--- a/desktop-app/release/app/package-lock.json
+++ b/desktop-app/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ResponsivelyApp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ResponsivelyApp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop-app/src/renderer/components/ReleaseNotes/index.tsx
+++ b/desktop-app/src/renderer/components/ReleaseNotes/index.tsx
@@ -120,6 +120,20 @@ const ReleaseNotes = () => {
           >
             Full Release Notes
           </Button>
+          <Button
+            onClick={() => {
+              window.electron.ipcRenderer.sendMessage(
+                IPC_MAIN_CHANNELS.OPEN_EXTERNAL,
+                {
+                  url: 'https://responsively.app/sponsor/',
+                }
+              );
+            }}
+            isActionButton
+            isActive
+          >
+            Sponsor
+          </Button>
         </div>
       </>
     </Modal>

--- a/desktop-app/src/renderer/components/ReleaseNotes/index.tsx
+++ b/desktop-app/src/renderer/components/ReleaseNotes/index.tsx
@@ -60,7 +60,7 @@ const ReleaseNotes = () => {
       isOpen={isOpen}
       onClose={closeAndMarkAsRead}
       title={
-        <span>
+        <span className="pl-2">
           What&apos;s New in <span className="font-bold">v{version}</span>{' '}
           &nbsp;&nbsp;🎉
         </span>
@@ -100,26 +100,29 @@ const ReleaseNotes = () => {
             {content}
           </ReactMarkdown>
         </div>
-        <div className="mt-10 flex justify-between gap-2 px-8">
-          <Button onClick={closeAndMarkAsRead} isActionButton>
-            Close
-          </Button>
-          <Button
-            onClick={() => {
-              window.electron.ipcRenderer.sendMessage(
-                IPC_MAIN_CHANNELS.OPEN_EXTERNAL,
-                {
-                  url: `https://github.com/responsively-org/responsively-app/releases/tag/v${version}`,
-                }
-              );
-              closeAndMarkAsRead();
-            }}
-            isActionButton
-            isActive
-            tabIndex={0}
-          >
-            Full Release Notes
-          </Button>
+        <div className="mt-10 flex justify-between gap-12">
+          <div className="flex">
+            <Button
+              onClick={() => {
+                window.electron.ipcRenderer.sendMessage(
+                  IPC_MAIN_CHANNELS.OPEN_EXTERNAL,
+                  {
+                    url: `https://github.com/responsively-org/responsively-app/releases/tag/v${version}`,
+                  }
+                );
+                closeAndMarkAsRead();
+              }}
+              isActionButton
+              isActive
+              tabIndex={0}
+            >
+              Release Notes
+            </Button>
+            <Button onClick={closeAndMarkAsRead} isActionButton>
+              Close
+            </Button>
+          </div>
+
           <Button
             onClick={() => {
               window.electron.ipcRenderer.sendMessage(
@@ -132,7 +135,7 @@ const ReleaseNotes = () => {
             isActionButton
             isActive
           >
-            Sponsor
+            Support Responsively App
           </Button>
         </div>
       </>


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
This changes resolves #940 

**About the PR :**

Added "Sponsor" button in the ` ReleaseNotes ` component which will take us to the website [sponsor page](https://responsively.app/sponsor/) .

Here is a preview of the Release Notes popup .

![image](https://github.com/responsively-org/responsively-app/assets/66641469/1edb8571-4670-4d80-9258-2d797d31c37a)

Tested the app after adding new button and everything seems to be working properly .