### PR TITLE
Fixed screenshot transparent website

### DIFF
--- a/desktop-app/src/main/screenshot/index.ts
+++ b/desktop-app/src/main/screenshot/index.ts
@@ -22,11 +22,28 @@ export interface ScreenshotAllArgs {
 export interface ScreenshotResult {
   done: boolean;
 }
-
 const captureImage = async (
   webContentsId: number
 ): Promise<Electron.NativeImage | undefined> => {
-  const Image = await webContents.fromId(webContentsId)?.capturePage();
+  const WebContents = webContents.fromId(webContentsId);
+
+  const isExecuted = await WebContents?.executeJavaScript(`
+    if (window.isExecuted) {
+      true;
+    }
+  `);
+
+  if (!isExecuted) {
+    await WebContents?.executeJavaScript(`
+      const bgColor = window.getComputedStyle(document.body).backgroundColor;
+      if (bgColor === 'rgba(0, 0, 0, 0)') {
+        document.body.style.backgroundColor = 'white';
+      } 
+      window.isExecuted = true;
+    `);
+  }
+
+  const Image = await WebContents?.capturePage();
   return Image;
 };
 


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

- Fixed screenshot not working well for transparent background website [#959]

### ℹ️ About the PR

Fixed by adding below code
```js
...
await WebContents?.executeJavaScript(`
      const bgColor = window.getComputedStyle(document.body).backgroundColor;
      if (bgColor === 'rgba(0, 0, 0, 0)') {
        document.body.style.backgroundColor = 'white';
      } 
      window.isExecuted = true;
 `);
```

### 🖼️ Testing Scenarios / Screenshots

- Before 
![image](https://github.com/responsively-org/responsively-app/assets/82715592/44bb596a-bc62-4aa7-81d3-77452928a488)

- After 
![image](https://github.com/responsively-org/responsively-app/assets/82715592/896885fa-7913-4b67-9f5d-b6dcc3e70ef0)

