### PR TITLE
Separated the individual layout icon from the rest of the icons for better visibility and tweaked the individual layout tabs design

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -123,48 +123,52 @@ const Toolbar = ({
   };
 
   return (
-    <div className="my-1 flex items-center gap-1">
-      <Button
-        onClick={quickScreenshot}
-        isLoading={screenshotLoading}
-        title="Quick Screenshot"
-      >
-        <div className="relative h-4 w-4">
+    <div className="flex items-center justify-between gap-1">
+      <div className="my-1 flex items-center gap-1">
+        <Button
+          onClick={quickScreenshot}
+          isLoading={screenshotLoading}
+          title="Quick Screenshot"
+        >
+          <div className="relative h-4 w-4">
+            <Icon
+              icon="ic:outline-photo-camera"
+              className="absolute top-0 left-0"
+            />
+            <Icon
+              icon="clarity:lightning-solid"
+              className="absolute top-[-1px] right-[-2px]"
+              height={8}
+            />
+          </div>
+        </Button>
+        <Button
+          onClick={fullScreenshot}
+          isLoading={fullScreenshotLoading}
+          title="Full Page Screenshot"
+        >
+          <Icon icon="ic:outline-photo-camera" />
+        </Button>
+        <Button
+          onClick={toggleEventMirroring}
+          isActive={eventMirroringOff}
+          title="Disable Event Mirroring"
+        >
+          <Icon icon="fluent:plug-disconnected-24-regular" />
+        </Button>
+        <Button onClick={openDevTools} title="Open Devtools">
+          <Icon icon="ic:round-code" />
+        </Button>
+        <Button onClick={rotate} isActive={rotated} title="Rotate This Device">
           <Icon
-            icon="ic:outline-photo-camera"
-            className="absolute top-0 left-0"
+            icon={
+              rotated
+                ? 'mdi:phone-rotate-portrait'
+                : 'mdi:phone-rotate-landscape'
+            }
           />
-          <Icon
-            icon="clarity:lightning-solid"
-            className="absolute top-[-1px] right-[-2px]"
-            height={8}
-          />
-        </div>
-      </Button>
-      <Button
-        onClick={fullScreenshot}
-        isLoading={fullScreenshotLoading}
-        title="Full Page Screenshot"
-      >
-        <Icon icon="ic:outline-photo-camera" />
-      </Button>
-      <Button
-        onClick={toggleEventMirroring}
-        isActive={eventMirroringOff}
-        title="Disable Event Mirroring"
-      >
-        <Icon icon="fluent:plug-disconnected-24-regular" />
-      </Button>
-      <Button onClick={openDevTools} title="Open Devtools">
-        <Icon icon="ic:round-code" />
-      </Button>
-      <Button onClick={rotate} isActive={rotated} title="Rotate This Device">
-        <Icon
-          icon={
-            rotated ? 'mdi:phone-rotate-portrait' : 'mdi:phone-rotate-landscape'
-          }
-        />
-      </Button>
+        </Button>
+      </div>
       <Button
         onClick={() => onIndividualLayoutHandler(device)}
         title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}

--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
@@ -42,11 +42,11 @@ const IndividualLayoutToolbar = ({
       <Tabs
         onSelect={onTabClick}
         selectedIndex={activeTab}
-        className={cx('react-tabs flex')}
+        className={cx('react-tabs flex flex-1')}
       >
         <TabList
           className={cx(
-            'custom-scrollbar flex gap-1  overflow-x-auto border-b border-slate-400/60 dark:border-white'
+            'custom-scrollbar flex flex-1  justify-center gap-1 overflow-x-auto border-b border-slate-400/60 dark:border-white'
           )}
         >
           {devices.map((device, idx) => (


### PR DESCRIPTION
Screenshot:
Device toolbar
<img width="1539" alt="Screenshot 2023-06-16 at 11 55 48 AM" src="https://github.com/responsively-org/responsively-app/assets/1283424/65574bfb-d18b-409e-8e81-d1a6a2357f30">

Individual layout tabs:
<img width="1831" alt="Screenshot 2023-06-16 at 12 16 21 PM" src="https://github.com/responsively-org/responsively-app/assets/1283424/f868af23-71ae-46f4-a21d-b7b106fa4f05">
