### PR TITLE
feature: hot-reloading for static web files

### DIFF
--- a/desktop-app/src/common/constants.ts
+++ b/desktop-app/src/common/constants.ts
@@ -27,6 +27,8 @@ export const IPC_MAIN_CHANNELS = {
   AUTH_RESPONSE: 'auth-response',
   OPEN_EXTERNAL: 'open-external',
   OPEN_URL: 'open-url',
+  START_WATCHING_FILE: 'start-watching-file',
+  STOP_WATCHER: 'stop-watcher',
 } as const;
 
 export type Channels = typeof IPC_MAIN_CHANNELS[keyof typeof IPC_MAIN_CHANNELS];

--- a/desktop-app/src/renderer/store/features/renderer/index.ts
+++ b/desktop-app/src/renderer/store/features/renderer/index.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { PreviewLayout } from 'common/constants';
+import { IPC_MAIN_CHANNELS, PreviewLayout } from 'common/constants';
 import type { RootState } from '../..';
 
 export interface RendererState {
@@ -34,12 +34,27 @@ const initialState: RendererState = {
   isCapturingScreenshot: false,
 };
 
+export const updateFileWatcher = (newURL: string) => {
+  if (
+    newURL.startsWith('file://') &&
+    (newURL.endsWith('.html') || newURL.endsWith('.htm'))
+  )
+    window.electron.ipcRenderer.sendMessage(
+      IPC_MAIN_CHANNELS.START_WATCHING_FILE,
+      {
+        path: newURL,
+      }
+    );
+  else window.electron.ipcRenderer.sendMessage(IPC_MAIN_CHANNELS.STOP_WATCHER);
+};
+
 export const rendererSlice = createSlice({
   name: 'renderer',
   initialState,
   reducers: {
     setAddress: (state, action: PayloadAction<string>) => {
       if (action.payload !== state.address) {
+        updateFileWatcher(action.payload);
         state.address = action.payload;
       }
     },


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
Fixes #969 

### ℹ️ About the PR
Hot-reloading for static html/js/css files even if they weren't running on a (local) development server.

### 🖼️ Testing Scenarios / Screenshots

[hot_reload_static_web_files.webm](https://github.com/responsively-org/responsively-app/assets/59393936/27f03991-6c64-4466-b1b5-25dfe6d3977a)
