### PR TITLE
fix: App is stuck when capturing all webviews on macOS

### DIFF
--- a/desktop-app/src/main/screenshot/index.ts
+++ b/desktop-app/src/main/screenshot/index.ts
@@ -58,7 +58,7 @@ const quickScreenshot = async (
   if (image === undefined) {
     return { done: false };
   }
-  const fileName = name.replace('/', '-').replace(':', '-');
+  const fileName = name.replaceAll('/', '-').replaceAll(':', '-');
   const dir = path.join(homedir(), `Desktop/Responsively-Screenshots`);
   const filePath = path.join(dir, `/${fileName}-${Date.now()}.jpeg`);
   await ensureDir(dir);

--- a/desktop-app/src/main/screenshot/index.ts
+++ b/desktop-app/src/main/screenshot/index.ts
@@ -38,7 +38,7 @@ const captureImage = async (
       const bgColor = window.getComputedStyle(document.body).backgroundColor;
       if (bgColor === 'rgba(0, 0, 0, 0)') {
         document.body.style.backgroundColor = 'white';
-      } 
+      }
       window.isExecuted = true;
     `);
   }
@@ -58,8 +58,9 @@ const quickScreenshot = async (
   if (image === undefined) {
     return { done: false };
   }
+  const fileName = name.replace('/', '-').replace(':', '-');
   const dir = path.join(homedir(), `Desktop/Responsively-Screenshots`);
-  const filePath = path.join(dir, `/${name}-${Date.now()}.jpeg`);
+  const filePath = path.join(dir, `/${fileName}-${Date.now()}.jpeg`);
   await ensureDir(dir);
   await writeFile(filePath, image.toJPEG(100));
   setTimeout(() => shell.showItemInFolder(filePath), 100);


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1003 

### ℹ️ About the PR

Capturing screenshots for devices that contain `/` in the name cause the app to get stuck on macOS. As explained on the issue `/` and `:` might cause issues on filenames on macOS therefore causing an exception when attempting to save the file.

### 🖼️ Testing Scenarios / Screenshots

![1003-screen-recording](https://github.com/responsively-org/responsively-app/assets/3981106/753497e7-2119-4be0-8daf-f4c75e1f430c)
