### PR TITLE
fix: bottom screen cut off #1022

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -426,7 +426,9 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
     };
   }, [dispatch, isPrimary]);
 
-  const scaledHeight = height * zoomfactor;
+  const scaledHeight = device.isMobileCapable
+    ? height * zoomfactor
+    : (height + device.dpi * 17) * zoomfactor;
   const scaledWidth = width * zoomfactor;
 
   return (

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -428,7 +428,7 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
 
   const scaledHeight = device.isMobileCapable
     ? height * zoomfactor
-    : (height + device.dpi * 17) * zoomfactor;
+    : (height + 30) * zoomfactor;
   const scaledWidth = width * zoomfactor;
 
   return (


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

#1022

### ℹ️ About the PR

Problem occurs in flex mode when a device which does not have ability to scroll is placed at the bottom. What I did is, I first check whether the device has a scrolling ability if not then I manipulate its height value. I first intended to make it scale with dpi value but noticed that not everything had one or you could change it manually. So, I settled with a value which probably will be okay for the most of the time. I can make a better solution with some help i.e. with scaling dpi (because there can be small white space left for some desktop screens since it does not scale with any constant, put in 2nd screen shot) but I feel like this is the best solution we can have right now. At least better than not seeing the bottom part of the page. 😅 

Note: This is my first contribution to any open source project, so feel free to point out where I can do better . 😄

### 🖼️ Testing Scenarios / Screenshots

<img width="1470" alt="Screenshot 2023-08-02 at 18 05 22" src="https://github.com/responsively-org/responsively-app/assets/72814782/52ff629f-aea4-47e5-87af-19850bb016ee">

<img width="1470" alt="Screenshot 2023-08-02 at 18 14 41" src="https://github.com/responsively-org/responsively-app/assets/72814782/02db4b5c-5f92-4922-89fd-e8ca86193449">

