### PR TITLE
Fix screenshot error from #1050

### DIFF
--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -258,7 +258,7 @@ app.on('certificate-error', (event, _, url, __, ___, callback) => {
     return callback(true);
   }
   console.log('certificate-error event', url, BROWSER_SYNC_HOST);
-  return callback(store.get('userPreferences.allowInsecureSSLConnections'));
+  return callback(store.get('allowInsecureSSLConnections'));
 });
 
 app

--- a/desktop-app/src/main/screenshot/index.ts
+++ b/desktop-app/src/main/screenshot/index.ts
@@ -59,7 +59,7 @@ const quickScreenshot = async (
     return { done: false };
   }
   const fileName = name.replaceAll('/', '-').replaceAll(':', '-');
-  const dir = store.get('userPreferences.screenshot.saveLocation');
+  const dir = store.get('screenshot.saveLocation');
   const filePath = path.join(dir, `/${fileName}-${Date.now()}.jpeg`);
   await ensureDir(dir);
   await writeFile(filePath, image.toJPEG(100));

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/AllowInSecureSSL/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/AllowInSecureSSL/index.tsx
@@ -3,7 +3,7 @@ import Toggle from 'renderer/components/Toggle';
 
 const AllowInSecureSSL = () => {
   const [allowed, setAllowed] = useState<boolean>(
-    window.electron.store.get('userPreferences.allowInsecureSSLConnections')
+    window.electron.store.get('allowInsecureSSLConnections')
   );
 
   return (
@@ -15,7 +15,7 @@ const AllowInSecureSSL = () => {
           onChange={(value) => {
             setAllowed(value.target.checked);
             window.electron.store.set(
-              'userPreferences.allowInsecureSSLConnections',
+              'allowInsecureSSLConnections',
               value.target.checked
             );
           }}

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const SettingsContent = ({ onClose }: Props) => {
   const id = useId();
   const [screenshotSaveLocation, setScreenshotSaveLocation] = useState<string>(
-    window.electron.store.get('userPreferences.screenshot.saveLocation')
+    window.electron.store.get('screenshot.saveLocation')
   );
 
   const onSave = () => {
@@ -20,7 +20,7 @@ export const SettingsContent = ({ onClose }: Props) => {
     }
 
     window.electron.store.set(
-      'userPreferences.screenshot.saveLocation',
+      'screenshot.saveLocation',
       screenshotSaveLocation
     );
     onClose();

--- a/desktop-app/src/store/index.ts
+++ b/desktop-app/src/store/index.ts
@@ -230,6 +230,6 @@ const schema = {
   },
 } as const;
 
-const store = new Store({ schema, migrations });
+const store = new Store({ schema, watch: true, migrations });
 
 export default store;

--- a/desktop-app/src/store/index.ts
+++ b/desktop-app/src/store/index.ts
@@ -131,24 +131,19 @@ const schema = {
     },
     default: {},
   },
-  userPreferences: {
+  screenshot: {
     type: 'object',
     properties: {
-      allowInsecureSSLConnections: {
-        type: 'boolean',
-        default: false,
-      },
-      screenshot: {
-        type: 'object',
-        properties: {
-          saveLocation: {
-            type: 'string',
-            default: path.join(homedir(), `Desktop/Responsively-Screenshots`),
-          },
-        },
-        default: {},
+      saveLocation: {
+        type: 'string',
+        default: path.join(homedir(), `Desktop/Responsively-Screenshots`),
       },
     },
+    default: {},
+  },
+  allowInsecureSSLConnections: {
+    type: 'boolean',
+    default: false,
   },
   webPermissions: {
     type: 'array',
@@ -235,6 +230,6 @@ const schema = {
   },
 } as const;
 
-const store = new Store({ schema, watch: true, migrations });
+const store = new Store({ schema, migrations });
 
 export default store;


### PR DESCRIPTION
Fix issue https://github.com/responsively-org/responsively-app/issues/1050 

- When taking screenshot it gives:
```
Error occurred in handler for 'screenshot': TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:399:5)
    at validateString (node:internal/validators:163:11)
    at Object.join (node:path:1172:7)
    at quickScreenshot (/home/yung/Documents/responsively-app/desktop-app/src/main/screenshot/index.ts:63:25)
    at async EventEmitter.<anonymous> (node:electron/js2c/browser_init:2:88864) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
- Which leads to Store(electron-store) schema of desktop-app/src/store/index.ts giving:
```
ResponsivelyApp encountered an error
Error: Config schema violation: `userPreferences` must be object
```
- And fixed this issue by spliting userPreference object from Store schema.
