### PR TITLE
[Feature] Refresh Feature for a single view

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -36,10 +36,10 @@ const Toolbar = ({
   const [rotated, setRotated] = useState<boolean>(false);
 
   const refreshView = () => {
-    if(webview){
-      webview.reload()
+    if (webview) {
+      webview.reload();
     }
-  }
+  };
 
   const toggleEventMirroring = async () => {
     if (webview == null) {

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -35,6 +35,12 @@ const Toolbar = ({
     useState<boolean>(false);
   const [rotated, setRotated] = useState<boolean>(false);
 
+  const refreshView = () => {
+    if(webview){
+      webview.reload()
+    }
+  }
+
   const toggleEventMirroring = async () => {
     if (webview == null) {
       return;
@@ -125,6 +131,9 @@ const Toolbar = ({
   return (
     <div className="flex items-center justify-between gap-1">
       <div className="my-1 flex items-center gap-1">
+        <Button onClick={refreshView} title="Refresh This View">
+          <Icon icon="ic:round-refresh" />
+        </Button>
         <Button
           onClick={quickScreenshot}
           isLoading={screenshotLoading}


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes #1064 

### ℹ️ About the PR

As described in the issue, there was a need of refreshing only a specific view without the need of using the console. The current state of the app contains a global refresh button on the left of the URL bar, which triggers a reload for every view in the app.

To fix the issue, a new button is added in the view specific toolbar, that will refresh **that** view without hampering other views.

### 🖼️ Testing Scenarios / Screenshots

Test: Changed some element's text in different views (using inspect element) and tried refreshing the views one at a time.

![refresh-button-closeup](https://github.com/responsively-org/responsively-app/assets/87022870/fd9b7262-2593-4bb2-a34c-3d957926ef40)

![refresh-view](https://github.com/responsively-org/responsively-app/assets/87022870/c1828eca-126b-44d7-a46c-1522fe4a3d90)

