### PR TITLE
Add ability to edit a custom device's name

### DIFF
--- a/desktop-app/src/renderer/components/DeviceManager/DeviceDetailsModal.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/DeviceDetailsModal.tsx
@@ -133,11 +133,8 @@ const DeviceDetailsModal = ({
               placeholder="My Mobile Device"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              disabled={!isCustom || !isNew}
+              disabled={!isCustom}
             />
-            {!isNew && isCustom ? (
-              <p>Note: Device name cannot be modified once created!</p>
-            ) : null}
             <Input
               label="Device Width"
               type="number"

--- a/desktop-app/src/renderer/components/DeviceManager/DeviceDetailsModal.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/DeviceDetailsModal.tsx
@@ -85,7 +85,11 @@ const DeviceDetailsModal = ({
   const isCustom = device != null ? device.isCustom ?? false : true;
 
   const handleAddDevice = async (): Promise<void> => {
-    if (device == null && existingDevices.find((d) => d.name === name)) {
+    const existingDevice = existingDevices.find((d) => d.name === name);
+    const doesDeviceExist =
+      existingDevice != null && (isNew || existingDevice.id !== device.id);
+
+    if (doesDeviceExist) {
       // eslint-disable-next-line no-alert
       return alert(
         'Device With the name already exists, try with a different name'


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
- Resolves #922 
- Resolves #749

### ℹ️ About the PR
In `DeviceDetailsModal.tsx`:

- only disable name input if it is not a custom device.
- remove the note informing user that they can not change the custom device's name
- Disallow the ability to change a custom device's name to an existing device's name in the `handleAddDevice` function
  -  I added this because it is already the existing behavior when adding a new custom device, and because it creates issues when checking/unchecking custom devices with the same name because the logic in `DeviceLabel.tsx` is still using name instead of id.

