### PR TITLE
[Feature] URLs can now be dragged onto the url bar

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -154,9 +154,7 @@ const AddressBar = () => {
   const handleDrop = (e: DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-
     const draggedText = e.dataTransfer.getData('text/plain');
-
     try {
       const draggedUrl = new URL(draggedText);
       if (draggedUrl.protocol === 'http:' || draggedUrl.protocol === 'https:') {

--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -162,7 +162,7 @@ const AddressBar = () => {
       } else {
         throw new Error('Invalid URL');
       }
-    } catch (e) {
+    } catch (err) {
       console.log('Invalid URL');
     }
   };
@@ -270,7 +270,7 @@ const AddressBar = () => {
         <div
           className={`${
             isDragOver ? 'opacity-100' : 'opacity-0'
-          } pointer-events-none absolute left-0 top-0 z-10 h-full w-full border-spacing-1 flex items-center justify-center gap-2 rounded-full border-2 border-dashed border-[#37b598] bg-[#92e2ce] dark:bg-[#86e0ca] duration-100 dark:text-slate-900`}
+          } pointer-events-none absolute left-0 top-0 z-10 flex h-full w-full border-spacing-1 items-center justify-center gap-2 rounded-full border-2 border-dashed border-[#37b598] bg-[#92e2ce] duration-100 dark:bg-[#86e0ca] dark:text-slate-900`}
         >
           <Icon icon="mdi:plus" />
           <p className="text-sm font-semibold">Drop URL Here</p>


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
Fixes #743 

### ℹ️ About the PR

This PR adds a drop zone functionality for dragging URLs to the URL bar in the app. You can now simply drag URLs from other apps / from one of the webviews, onto Responsively's URL bar.

### 🖼️ Testing Scenarios / Screenshots

Can drag URLs from other apps as well as from one of the webviews of Responsively.

![drop-url-to-toolbar](https://github.com/responsively-org/responsively-app/assets/87022870/80b76a0c-0971-4329-81a4-4000510ebe07)

![draggable-url](https://github.com/responsively-org/responsively-app/assets/87022870/c79e65ef-4cc3-49f8-8368-c27d191f791b)

