### PR TITLE
added  useDetectionOutside for bookmark

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/BookmarkButton.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/BookmarkButton.tsx
@@ -1,8 +1,10 @@
 import { Icon } from '@iconify/react';
 import { useState, useMemo } from 'react';
+import { useDetectClickOutside } from 'react-detect-click-outside';
 import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import Button from 'renderer/components/Button';
+
 import {
   IBookmarks,
   addBookmark,
@@ -21,6 +23,12 @@ interface Props {
 const BookmarkButton = ({ currentAddress, pageTitle }: Props) => {
   const [openFlyout, setOpenFlyout] = useState<boolean>(false);
   const dispatch = useDispatch();
+  const ref = useDetectClickOutside({
+    onTriggered: () => {
+      if (!openFlyout) return;
+      if (openFlyout) setOpenFlyout(false);
+    },
+  });
 
   const initbookmark = {
     id: '',
@@ -48,7 +56,7 @@ const BookmarkButton = ({ currentAddress, pageTitle }: Props) => {
   useKeyboardShortcut(SHORTCUT_CHANNEL.BOOKMARK, handleKeyboardShortcut);
 
   return (
-    <>
+    <div ref={ref}>
       <div>
         <Button
           className={cx('rounded-full', {
@@ -71,7 +79,7 @@ const BookmarkButton = ({ currentAddress, pageTitle }: Props) => {
           />
         )}
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

this is not an opened issue, this is the small feature when I used with the app I found out

### ℹ️ About the PR

I found out when you click on bookmark icon and the menu opens, it will never close unless you click the icon again and it was a little bit annoying to me. so I added a function to detect outside click and the close the menu not just by clicking on icon!

### 🖼️ Testing Scenarios / Screenshots


https://github.com/responsively-org/responsively-app/assets/113235504/c4acbaf0-2e7c-46da-8002-f3cea1ffe044

