### PR TITLE
Fixed issue #1100

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -252,7 +252,7 @@ const AddressBar = () => {
           ref={inputRef}
           type="text"
           className={cx(
-            'w-full text-ellipsis rounded-full px-2 py-1 pl-8 pr-20 dark:bg-slate-900',
+            'w-full text-ellipsis rounded-full px-2 py-1 pl-8 pr-40 dark:bg-slate-900',
             {
               'rounded-tl-lg rounded-tr-lg rounded-bl-none rounded-br-none outline-none':
                 isSuggesting,


### PR DESCRIPTION
Resolved the issue of overlapping between URL text and icons within the address bar. The change addresses the problem illustrated below:

Before:

![Screenshot from 2023-09-28 17-05-56](https://github.com/responsively-org/responsively-app/assets/99260988/985e6090-f72d-4479-bb5d-6039e579f05f)


After:

![Screenshot from 2023-09-28 17-05-39](https://github.com/responsively-org/responsively-app/assets/99260988/5b1ee876-e58e-46dd-a827-cff246e21ac1)
