### PR TITLE
Replaced broken slack link to Discord in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
   
 
 
-  <a href="https://responsively.app/join-slack" target="_blank">
-    <img src="https://img.shields.io/badge/Join%20on-Slack-brightgreen?logo=slack" alt="Slack">
+  <a href="https://responsively.app/join-discord" target="_blank">
+    <img src="https://img.shields.io/badge/Join%20-Discord-blue?logo=discord&logoColor=white" alt="Discord">
   </a>
 
   <a href="https://xscode.com/manojvivek/responsively-app" target="_blank">


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

### ℹ️ About the PR

The broken slack link on the main `README.md` was replaced to the updated Discord channel. 

### 🖼️ Testing Scenarios / Screenshots
![join-discord-link](https://github.com/responsively-org/responsively-app/assets/87022870/fc7eda54-f664-48ad-ab4f-a5acf371c45d)

