### PR TITLE
Add device button added to the preview area

### DIFF
--- a/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/index.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/index.tsx
@@ -14,7 +14,9 @@ export const PreviewSuites = () => {
 
   return (
     <div className="flex flex-col">
-      <p className="mb-6 text-lg">Preview Suites</p>
+      <p className="mb-6 flex items-center gap-2 text-lg">
+        <Icon icon="heroicons:swatch" /> Preview Suites
+      </p>
       <div className="flex w-full items-center gap-4 overflow-x-auto">
         <div className="flex flex-shrink-0 gap-4">
           {suites.map((suite) => (

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import { DOCK_POSITION, PREVIEW_LAYOUTS } from 'common/constants';
@@ -9,9 +9,12 @@ import {
 import { getDevicesMap, Device as IDevice } from 'common/deviceList';
 import { useState } from 'react';
 import { selectLayout } from 'renderer/store/features/renderer';
+import { Icon } from '@iconify/react';
+import { APP_VIEWS, setAppView } from 'renderer/store/features/ui';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
 import IndividualLayoutToolbar from './IndividualLayoutToolBar';
+import Button from '../Button';
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -20,6 +23,7 @@ const Previewer = () => {
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
+  const dispatch = useDispatch();
 
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
@@ -65,6 +69,17 @@ const Previewer = () => {
                   setIndividualDevice={setIndividualDevice}
                 />
               ))}
+              <Button
+                isTextButton
+                className="h-fit gap-2 whitespace-nowrap text-sm"
+                isPrimary
+                onClick={() => {
+                  dispatch(setAppView(APP_VIEWS.DEVICE_MANAGER));
+                }}
+              >
+                <Icon icon="mdi:plus" />
+                Add Device
+              </Button>
             </>
           )}
         </div>

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import cx from 'classnames';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import { DOCK_POSITION, PREVIEW_LAYOUTS } from 'common/constants';
@@ -9,12 +9,9 @@ import {
 import { getDevicesMap, Device as IDevice } from 'common/deviceList';
 import { useState } from 'react';
 import { selectLayout } from 'renderer/store/features/renderer';
-import { Icon } from '@iconify/react';
-import { APP_VIEWS, setAppView } from 'renderer/store/features/ui';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
 import IndividualLayoutToolbar from './IndividualLayoutToolBar';
-import Button from '../Button';
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -23,7 +20,6 @@ const Previewer = () => {
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
-  const dispatch = useDispatch();
 
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
@@ -69,17 +65,6 @@ const Previewer = () => {
                   setIndividualDevice={setIndividualDevice}
                 />
               ))}
-              <Button
-                isTextButton
-                className="h-fit gap-2 whitespace-nowrap text-sm"
-                isPrimary
-                onClick={() => {
-                  dispatch(setAppView(APP_VIEWS.DEVICE_MANAGER));
-                }}
-              >
-                <Icon icon="mdi:plus" />
-                Add Device
-              </Button>
             </>
           )}
         </div>

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -13,6 +13,7 @@ import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import WebPage from 'main/screenshot/webpage';
 import { getDevicesMap } from 'common/deviceList';
 import { updateWebViewHeightAndScale } from 'common/webViewUtils';
+import { APP_VIEWS, setAppView } from 'renderer/store/features/ui';
 import NavigationControls from './NavigationControls';
 import Menu from './Menu';
 import Button from '../Button';
@@ -137,6 +138,13 @@ const ToolBar = () => {
       <ColorBlindnessControls />
       <Divider />
       <PreviewSuiteSelector />
+      <Button
+        onClick={() => {
+          dispatch(setAppView(APP_VIEWS.DEVICE_MANAGER));
+        }}
+      >
+        <Icon icon="lucide:plus" width={16} />
+      </Button>
       <Menu />
       <ModalLoader
         isOpen={isCapturingScreenshot}


### PR DESCRIPTION
Based on user feedback on Discord, adding a button to make the device manager easily identifiable. 

Screenshot
<img width="573" alt="Screenshot 2024-06-07 at 1 10 21 PM" src="https://github.com/responsively-org/responsively-app/assets/1283424/4e46a663-14f2-44a8-be1c-d9597908379a">
