### PR TITLE
fix: show ctrl as mod button in shortcut modal for windows devices

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
@@ -5,11 +5,10 @@ interface Props {
 const ShortcutButton = ({ text }: Props) => {
   const btnText = text[0].split('+');
   const btnTextLength = btnText.length - 1;
-  const { platform = '' } = navigator?.userAgentData || {};
 
   const formatText = (value: string) => {
     if (value === 'mod') {
-      if (platform.includes('Windows')) {
+      if (navigator?.userAgent?.includes('Windows')) {
         return `Ctrl`;
       }
       return `⌘`;

--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
@@ -5,8 +5,16 @@ interface Props {
 const ShortcutButton = ({ text }: Props) => {
   const btnText = text[0].split('+');
   const btnTextLength = btnText.length - 1;
+  const { platform = '' } = navigator?.userAgentData || {};
+
   const formatText = (value: string) => {
-    if (value === 'mod') return `⌘`;
+    if (value === 'mod') {
+      if (platform.includes('Windows')) {
+        return `Ctrl`;
+      }
+      return `⌘`;
+    }
+
     if (value.length === 1) return value.toUpperCase();
     return value;
   };


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
Fixes: #1185 

### ℹ️ About the PR

Currently for all the platform, shortcut mod is key visible as '⌘'. It should be Ctrl for windows devices.

### 🖼️ Testing Scenarios / Screenshots
<img width="429" alt="Screenshot 2024-01-19 at 11 02 37 PM" src="https://github.com/responsively-org/responsively-app/assets/102910293/0b9b5c8b-0ca0-46d0-b0ca-909b0713529d">


