### PR TITLE
fix: lock screenshot if screenshot capturing already in progress

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -40,6 +40,10 @@ const ToolBar = () => {
   }
 
   const screenshotCaptureHandler = async () => {
+    if (isCapturingScreenshot) {
+      return;
+    }
+
     dispatch(setIsCapturingScreenshot(true));
     const webViews: NodeListOf<Electron.WebviewTag> =
       document.querySelectorAll('webView');


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
Fixes: #984

### ℹ️ About the PR
If screenshot is already in progress then do not allow to take screenshot again.


### 🖼️ Testing Scenarios / Screenshots
NA
