### PR TITLE
Show ctrl as mod button in shortcut modal for windows/linux

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
@@ -6,7 +6,12 @@ const ShortcutButton = ({ text }: Props) => {
   const btnText = text[0].split('+');
   const btnTextLength = btnText.length - 1;
   const formatText = (value: string) => {
-    if (value === 'mod') return `⌘`;
+    if (value === 'mod') {
+      if (navigator?.userAgent?.includes('Windows')) {
+        return 'ctrl';
+      }
+      return '⌘';
+    }
     if (value.length === 1) return value.toUpperCase();
     return value;
   };


### PR DESCRIPTION
**Pull Request**
Issue: #1185 

**About:**
In shortcuts modal, mac cmd icons appear in all operating systems.