### PR TITLE
Add ability to pinch to zoom in Previewer area using trackpad

### DIFF
--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -239,6 +239,11 @@ const createWindow = async () => {
   ipcMain.on('stop-watcher', async () => {
     await stopWatchFiles();
   });
+
+  // detecting a pinch-to-zoom from a trackpad
+  ipcMain.on('pass-zoom-data', (_, scale) => {
+    mainWindow?.webContents.send('update-zoom-factor', scale);
+  });
   // Remove this if your app does not use auto updates
   // eslint-disable-next-line
   new AppUpdater();

--- a/desktop-app/src/main/preload-webview.ts
+++ b/desktop-app/src/main/preload-webview.ts
@@ -22,6 +22,12 @@ const documentBodyInit = () => {
       innerHeight: document.body.scrollHeight,
       innerWidth: window.innerWidth,
     });
+
+    // detecting a pinch-to-zoom from a trackpad
+    if (e.ctrlKey) {
+      const scale = Math.exp(-e.deltaY / 100);
+      ipcRenderer.send('pass-zoom-data', scale);
+    }
   });
 
   window.addEventListener('dom-ready', () => {

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -39,6 +39,7 @@ import {
   setIsInspecting,
   setLayout,
   setPageTitle,
+  setZoomFactor,
 } from 'renderer/store/features/renderer';
 import { PREVIEW_LAYOUTS } from 'common/constants';
 import { NAVIGATION_EVENTS } from '../../ToolBar/NavigationControls';
@@ -401,6 +402,20 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
       window.electron.ipcRenderer.removeListener('reload', reloadHandler);
     };
   }, [ref]);
+
+  useEffect(() => {
+    // zoom in or out when user pinches to zoom on a trackpad
+
+    const onUpdateZoomFactor = (scale: number) => {
+      dispatch(setZoomFactor(zoomfactor * scale));
+    };
+
+    window.electron.ipcRenderer.on('update-zoom-factor', onUpdateZoomFactor);
+
+    return () => {
+      window.electron.ipcRenderer.removeAllListeners('update-zoom-factor');
+    };
+  }, [zoomfactor, dispatch]);
 
   useEffect(() => {
     if (!ref.current) {

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import cx from 'classnames';
 import { selectActiveSuite } from 'renderer/store/features/device-manager';
 import { DOCK_POSITION, PREVIEW_LAYOUTS } from 'common/constants';
@@ -8,7 +8,11 @@ import {
 } from 'renderer/store/features/devtools';
 import { getDevicesMap, Device as IDevice } from 'common/deviceList';
 import { useState } from 'react';
-import { selectLayout } from 'renderer/store/features/renderer';
+import {
+  selectLayout,
+  setZoomFactor,
+  selectZoomFactor,
+} from 'renderer/store/features/renderer';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
 import IndividualLayoutToolbar from './IndividualLayoutToolBar';
@@ -20,11 +24,20 @@ const Previewer = () => {
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
+  const zoomfactor = useSelector(selectZoomFactor);
+  const dispatch = useDispatch();
 
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
+  const onPinchToZoom = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.ctrlKey) {
+      const scale = Math.exp(-e.deltaY / 100);
+      dispatch(setZoomFactor(zoomfactor * scale));
+    }
+  };
+
   return (
-    <div className="h-full">
+    <div className="h-full" onWheel={onPinchToZoom}>
       {isIndividualLayout && (
         <IndividualLayoutToolbar
           individualDevice={individualDevice}

--- a/desktop-app/src/store/index.ts
+++ b/desktop-app/src/store/index.ts
@@ -22,13 +22,13 @@ const schema = {
   renderer: {
     type: 'object',
     properties: {
-      individualZoomStepIndex: {
+      individualZoomFactor: {
         type: 'number',
-        default: 8,
+        default: 1,
       },
-      zoomStepIndex: {
+      zoomFactor: {
         type: 'number',
-        default: 3,
+        default: 0.55,
       },
     },
     default: {},


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
- Resolves #1049

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->

### ℹ️ About the PR

It looks like there may have been some confusion in the original issue as to exactly what the functional requirements should be of this new feature. Based on your comments, **my interpretation was that the user should be able to pinch-to-zoom on a trackpad in the preview area, which should zoom the devices in or out by updating the `zoomFactor` state variable.**

- Initially, I only added a `setZoomFactor` reducer and added an `onWheel` event listener in the `Previewer` component. This only worked when the mouse **was not** hovering over a `webview` element. When it was, the event listener would not fire. I did some searching through the [docs](https://www.electronjs.org/docs/latest/api/webview-tag#internal-implementation) and apparently "You can not add keyboard, mouse, and scroll event listeners to `webview`."
- GIven that limitation, I decided that this would probably require IPC. So I used  `ipcRenderer` and `ipcMain` modules to communicate the zoom gesture from the WebView to the main process.
- Because pinch-to-zoom essentially allows "infinite" zoom steps, I had to rewrite the `zoomIn` and `zoomOut` to cover the instances when the user might pinch-to-zoom and fall in-between one of the predefined zoom steps, and then later use the zoom buttons. I rewrote the reducers to find the nearest predefined step (i.e. if the user pinched-to-zoom and landed on 40%, and then later used the zoom in button, it should go up to 50%. Or if they zoomed out from 40%, it should go to 33%).
- I also made it so that the `individualZoomFactor` and `zoomFactor` in the Electron store are based on actual values instead of indices of the zoomSteps array. Again, because pinch-to-zoom allows "infinite" steps, I wanted to make it so that the application would remember the last `zoomFactor` even if it fell in between two pre-defined zoom steps.

I do have some concerns about the performance of this feature, as pinching-to-zoom can cause hundreds of re-rerenders, which sometimes caused some visible stuttering. The only other solution I could think of was updating the scale of the `webview` tags directly through CSS using a ref, and using some kind of debouncing function to only update the `zoomFactor` once the user has stopped pinching. I tested this and while it was visibly smoother, I ultimately decided against it because it required a lot more work-arounds and seemed a bit like an anti-pattern for React overall.

Hopefully I haven't missed anything. I'd be happy to make any requested changes to this implementation!

(sidenote: are the devices supposed to have that white space underneath? The prod application doesn't seem to have this but running the app locally, even on the `master` branch does for me.)

### 🖼️ Testing Scenarios / Screenshots

https://github.com/responsively-org/responsively-app/assets/49458912/91f9cb73-ccbd-41a8-b994-f4f312918631


