### PR TITLE
Removed non-functional 'Open' button

### DIFF
--- a/desktop-app/src/main/menu/index.ts
+++ b/desktop-app/src/main/menu/index.ts
@@ -128,10 +128,6 @@ export default class MenuBuilder {
         label: '&File',
         submenu: [
           {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
-          },
-          {
             label: '&Close',
             accelerator: 'Ctrl+W',
             click: () => {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1170 

### ℹ️ About the PR

This PR removes the non-functional "File > Open" button in the Responsively App. Since the app focuses on website responsiveness testing, users shouldn't expect traditional file opening functionality. Eliminating this button improves clarity and reduces potential user confusion. 

### 🖼️ Testing Scenarios / Screenshots

I've launched the modified Responsively App and verified that the "Open" button no longer appears in the menu. Additionally, I've tested core app functionality to ensure the change doesn't introduce any new issues. 

![responsively-before](https://github.com/responsively-org/responsively-app/assets/163606470/6dfcc648-efa7-4db6-b525-0d9012175ec5)
![responsively-after](https://github.com/responsively-org/responsively-app/assets/163606470/e0998e13-5617-4fa1-81f7-5a0ac0b04929)

