### PR TITLE
Update index.ts

### DIFF
--- a/desktop-app/src/renderer/store/features/bookmarks/index.ts
+++ b/desktop-app/src/renderer/store/features/bookmarks/index.ts
@@ -38,17 +38,17 @@ export const bookmarksSlice = createSlice({
       window.electron.store.set('bookmarks', bookmarks);
     },
     removeBookmark: (state, action) => {
-      const bookmarks = window.electron.store.get('bookmarks');
-      const bookmarkIndex = state.bookmarks.findIndex(
-        (bookmark) => bookmark.id === action.payload.id
-      );
-      if (bookmarkIndex === -1) {
-        return;
-      }
-      bookmarks.splice(bookmarkIndex, 1);
-      state.bookmarks = bookmarks;
-      window.electron.store.set('bookmarks', bookmarks);
-    },
+  const bookmarks = window.electron.store.get('bookmarks');
+  const bookmarkIndex = bookmarks.findIndex(
+    (bookmark) => bookmark.id === action.payload.id
+  );
+  if (bookmarkIndex === -1) {
+    return;
+  }
+  bookmarks.splice(bookmarkIndex, 1);
+  state.bookmarks = bookmarks;
+  window.electron.store.set('bookmarks', bookmarks);
+},
   },
 });
 


### PR DESCRIPTION
The bug in the removeBookmark function is due to the incorrect usage of state.bookmarks.findIndex instead of bookmarks.findIndex. This leads to an incorrect index calculation, resulting in the bookmark not being removed as expected

# ✨ Pull Request

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->
