### PR TITLE
[Tests] extract jest config to file, add jest commands, add mocks and add missing tests

### DIFF
--- a/desktop-app/jest.config.js
+++ b/desktop-app/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  moduleDirectories: ['node_modules', 'release/app/node_modules', 'src'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/.erb/mocks/fileMock.js',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+  },
+  setupFiles: ['./.erb/scripts/check-build-exists.ts'],
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    url: 'http://localhost/',
+  },
+  testPathIgnorePatterns: ['release/app/dist', '.erb/dll'],
+  transform: {
+    '\\.(ts|tsx|js|jsx)$': 'ts-jest',
+  },
+};

--- a/desktop-app/jest.config.js
+++ b/desktop-app/jest.config.js
@@ -6,7 +6,10 @@ module.exports = {
       '<rootDir>/.erb/mocks/fileMock.js',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
   },
-  setupFiles: ['./.erb/scripts/check-build-exists.ts'],
+  setupFiles: [
+    './.erb/scripts/check-build-exists.ts',
+    '<rootDir>/setupTests.js',
+  ],
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     url: 'http://localhost/',

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -38,7 +38,8 @@
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:preloadWebview": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload-webview.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
-    "test": "jest",
+    "test": "jest --config ./jest.config.js",
+    "test:watch": "jest --watch --config ./jest.config.js",
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
@@ -69,38 +70,6 @@
         }
       }
     ]
-  },
-  "jest": {
-    "moduleDirectories": [
-      "node_modules",
-      "release/app/node_modules",
-      "src"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "ts",
-      "tsx",
-      "json"
-    ],
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/.erb/mocks/fileMock.js",
-      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
-    },
-    "setupFiles": [
-      "./.erb/scripts/check-build-exists.ts"
-    ],
-    "testEnvironment": "jsdom",
-    "testEnvironmentOptions": {
-      "url": "http://localhost/"
-    },
-    "testPathIgnorePatterns": [
-      "release/app/dist",
-      ".erb/dll"
-    ],
-    "transform": {
-      "\\.(ts|tsx|js|jsx)$": "ts-jest"
-    }
   },
   "dependencies": {
     "@fontsource/lato": "^5.0.17",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -40,6 +40,7 @@
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest --config ./jest.config.js",
     "test:watch": "jest --watch --config ./jest.config.js",
+    "test:coverage": "jest --coverage --config ./jest.config.js",
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {

--- a/desktop-app/setupTests.js
+++ b/desktop-app/setupTests.js
@@ -1,0 +1,39 @@
+window.electron = {
+  ipcRenderer: {
+    sendMessage<T>(channel: Channels, ...args: T[]): void {
+      throw new Error('Function not implemented.');
+    },
+    on<T>(
+      channel: string,
+      func: (...args: T[]) => void
+    ): (() => void) | undefined {
+      throw new Error('Function not implemented.');
+    },
+    once<T>(channel: string, func: (...args: T[]) => void): void {
+      throw new Error('Function not implemented.');
+    },
+    invoke<T, P>(channel: string, ...args: T[]): Promise<P> {
+      throw new Error('Function not implemented.');
+    },
+    removeListener<T>(channel: string, func: (...args: T[]) => void): void {
+      throw new Error('Function not implemented.');
+    },
+    removeAllListeners(channel: string): void {
+      throw new Error('Function not implemented.');
+    },
+  },
+  store: {
+    set: jest.fn(), // Mock the `set` function
+    get: jest.fn(), // Mock the `get` function if needed in other parts of your tests
+  },
+};
+
+global.IntersectionObserver = jest.fn(() => ({
+  root: null,
+  rootMargin: '',
+  thresholds: [],
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+  takeRecords: jest.fn(),
+}));

--- a/desktop-app/setupTests.js
+++ b/desktop-app/setupTests.js
@@ -1,30 +1,15 @@
 window.electron = {
   ipcRenderer: {
-    sendMessage<T>(channel: Channels, ...args: T[]): void {
-      throw new Error('Function not implemented.');
-    },
-    on<T>(
-      channel: string,
-      func: (...args: T[]) => void
-    ): (() => void) | undefined {
-      throw new Error('Function not implemented.');
-    },
-    once<T>(channel: string, func: (...args: T[]) => void): void {
-      throw new Error('Function not implemented.');
-    },
-    invoke<T, P>(channel: string, ...args: T[]): Promise<P> {
-      throw new Error('Function not implemented.');
-    },
-    removeListener<T>(channel: string, func: (...args: T[]) => void): void {
-      throw new Error('Function not implemented.');
-    },
-    removeAllListeners(channel: string): void {
-      throw new Error('Function not implemented.');
-    },
+    sendMessage: jest.fn(),
+    on: jest.fn(),
+    once: jest.fn(),
+    invoke: jest.fn(),
+    removeListener: jest.fn(),
+    removeAllListeners: jest.fn(),
   },
   store: {
-    set: jest.fn(), // Mock the `set` function
-    get: jest.fn(), // Mock the `get` function if needed in other parts of your tests
+    set: jest.fn(),
+    get: jest.fn(),
   },
 };
 

--- a/desktop-app/src/renderer/components/Button/Button.test.tsx
+++ b/desktop-app/src/renderer/components/Button/Button.test.tsx
@@ -1,0 +1,87 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import Button from './index';
+
+jest.mock('@iconify/react', () => ({
+  Icon: () => <div data-testid="icon" />,
+}));
+
+describe('Button Component', () => {
+  it('renders with default props', () => {
+    render(<Button>Click me</Button>);
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  it('applies custom class name', () => {
+    render(<Button className="custom-class">Click me</Button>);
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).toHaveClass('custom-class');
+  });
+
+  it('renders loading icon when isLoading is true', () => {
+    render(<Button isLoading>Click me</Button>);
+    const loadingIcon = screen.getByTestId('icon');
+    expect(loadingIcon).toBeInTheDocument();
+  });
+
+  it('renders confirmation icon when loading is done', () => {
+    jest.useFakeTimers();
+    const { rerender } = render(<Button isLoading>Click me</Button>);
+
+    act(() => {
+      rerender(<Button isLoading={false}>Click me</Button>);
+      jest.runAllTimers(); // Use act to advance timers
+    });
+
+    const confirmationIcon = screen.getByTestId('icon');
+    expect(confirmationIcon).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('applies primary button styles', () => {
+    render(<Button isPrimary>Click me</Button>);
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).toHaveClass('bg-emerald-500');
+    expect(buttonElement).toHaveClass('text-white');
+  });
+
+  it('applies action button styles', () => {
+    render(<Button isActionButton>Click me</Button>);
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).toHaveClass('bg-slate-200');
+  });
+
+  it('applies subtle hover styles', () => {
+    render(<Button subtle>Click me</Button>);
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).toHaveClass('hover:bg-slate-200');
+  });
+
+  it('disables hover effects when disableHoverEffects is true', () => {
+    render(
+      <Button disableHoverEffects subtle>
+        Click me
+      </Button>
+    );
+    const buttonElement = screen.getByRole('button', { name: /click me/i });
+    expect(buttonElement).not.toHaveClass('hover:bg-slate-200');
+  });
+
+  it('renders children correctly when not loading or loading done', () => {
+    render(<Button>Click me</Button>);
+    const buttonElement = screen.getByText('Click me');
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  it('does not render children when loading or loading done', () => {
+    const { rerender } = render(<Button isLoading>Click me</Button>);
+    expect(screen.queryByText('Click me')).not.toBeInTheDocument();
+
+    act(() => {
+      rerender(<Button isLoading={false}>Click me</Button>);
+    });
+
+    expect(screen.queryByText('Click me')).not.toBeInTheDocument();
+  });
+});

--- a/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Device } from 'common/deviceList';
 import { Provider, useDispatch } from 'react-redux';

--- a/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { ManageSuitesTool } from './ManageSuitesTool';
+import deviceManagerReducer, {
+  addSuites,
+  deleteAllSuites,
+} from 'renderer/store/features/device-manager';
+import { transformFile } from './utils';
+import { ReactNode } from 'react';
+import { JSX } from 'react/jsx-runtime';
+import '@testing-library/jest-dom';
+import { Channels } from 'common/constants';
+
+jest.mock('renderer/store/features/device-manager', () => ({
+  addSuites: jest.fn(() => ({ type: 'addSuites' })),
+  deleteAllSuites: jest.fn(() => ({ type: 'deleteAllSuites' })),
+}));
+
+jest.mock('./utils', () => ({
+  transformFile: jest.fn(),
+}));
+
+jest.mock('./helpers', () => ({
+  onFileDownload: jest.fn(),
+  setCustomDevices: jest.fn(),
+}));
+
+const renderWithRedux = (
+  component:
+    | string
+    | number
+    | boolean
+    | Iterable<ReactNode>
+    | JSX.Element
+    | null
+    | undefined
+) => {
+  const store = configureStore({
+    reducer: {
+      deviceManager: deviceManagerReducer,
+    },
+  });
+
+  return {
+    ...render(<Provider store={store}>{component}</Provider>),
+    store,
+  };
+};
+
+describe('ManageSuitesTool', () => {
+  let setCustomDevicesStateMock: jest.Mock<any, any>;
+
+  beforeAll(() => {
+    window.electron = {
+      ipcRenderer: {
+        sendMessage: function <T>(channel: Channels, ...args: T[]): void {
+          throw new Error('Function not implemented.');
+        },
+        on: function <T>(
+          channel: string,
+          func: (...args: T[]) => void
+        ): (() => void) | undefined {
+          throw new Error('Function not implemented.');
+        },
+        once: function <T>(
+          channel: string,
+          func: (...args: T[]) => void
+        ): void {
+          throw new Error('Function not implemented.');
+        },
+        invoke: function <T, P>(channel: string, ...args: T[]): Promise<P> {
+          throw new Error('Function not implemented.');
+        },
+        removeListener: function <T>(
+          channel: string,
+          func: (...args: T[]) => void
+        ): void {
+          throw new Error('Function not implemented.');
+        },
+        removeAllListeners: function (channel: string): void {
+          throw new Error('Function not implemented.');
+        },
+      },
+      store: {
+        set: jest.fn(), // Mock the `set` function
+        get: jest.fn(), // Mock the `get` function if needed in other parts of your tests
+      },
+    };
+
+    global.IntersectionObserver = jest.fn(() => ({
+      root: null,
+      rootMargin: '',
+      thresholds: [],
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+      takeRecords: jest.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    setCustomDevicesStateMock = jest.fn();
+
+    renderWithRedux(
+      <ManageSuitesTool setCustomDevicesState={setCustomDevicesStateMock} />
+    );
+  });
+
+  it('renders the component correctly', () => {
+    expect(screen.getByTestId('download-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('upload-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('reset-btn')).toBeInTheDocument();
+  });
+
+  it('opens the modal when download button is clicked', () => {
+    fireEvent.click(screen.getByTestId('download-btn'));
+    expect(screen.getByText('Import your devices')).toBeInTheDocument();
+  });
+
+  it('opens the reset confirmation dialog when reset button is clicked', () => {
+    fireEvent.click(screen.getByTestId('reset-btn'));
+    expect(
+      screen.getByText('Do you want to reset all settings?')
+    ).toBeInTheDocument();
+  });
+
+  it('closes the reset confirmation dialog when the close button is clicked', () => {
+    fireEvent.click(screen.getByTestId('reset-btn'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(
+      screen.queryByText('Do you want to reset all settings?')
+    ).not.toBeInTheDocument();
+  });
+
+  it.only('dispatches deleteAllSuites and clears custom devices on reset confirmation', async () => {
+    fireEvent.click(screen.getByTestId('reset-btn'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(deleteAllSuites).toHaveBeenCalled();
+      expect(setCustomDevicesStateMock).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('handles file upload and dispatches actions correctly', async () => {
+    const file = new File(['test'], 'test.json', { type: 'application/json' });
+
+    (transformFile as jest.Mock).mockResolvedValueOnce({
+      customDevices: ['device1', 'device2'],
+      suites: ['suite1', 'suite2'],
+    });
+
+    fireEvent.click(screen.getByTestId('download-btn'));
+
+    const input = screen.getByLabelText('Upload File');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(setCustomDevicesStateMock).toHaveBeenCalled();
+      expect(addSuites).toHaveBeenCalled();
+      expect(screen.queryByText('Import your devices')).not.toBeInTheDocument();
+    });
+  });
+
+  it('handles file upload error and shows error message', async () => {
+    const file = new File(['test'], 'test.json', { type: 'application/json' });
+
+    (transformFile as jest.Mock).mockRejectedValueOnce(new Error('Test Error'));
+
+    fireEvent.click(screen.getByTestId('download-btn'));
+
+    const input = screen.getByLabelText('Upload File');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('An error occurred')).toBeInTheDocument();
+    });
+  });
+});

--- a/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/ManageSuitesTool.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Device } from 'common/deviceList';
 import { Provider, useDispatch } from 'react-redux';
@@ -7,7 +8,6 @@ import {
   deleteAllSuites,
 } from 'renderer/store/features/device-manager';
 import { ReactNode } from 'react';
-import { JSX } from 'react/jsx-runtime';
 import { transformFile } from './utils';
 import { ManageSuitesTool } from './ManageSuitesTool';
 

--- a/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/helpers.test.tsx
+++ b/desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/helpers.test.tsx
@@ -1,0 +1,138 @@
+import '@testing-library/jest-dom';
+// import { downloadFile, onFileDownload, setCustomDevices } from './helpers';
+
+import { Device } from 'common/deviceList';
+import { fireEvent, render } from '@testing-library/react';
+import Button from 'renderer/components/Button';
+import * as Helpers from './helpers';
+
+describe('onFileDownload', () => {
+  beforeAll(() => {
+    global.URL.createObjectURL = jest.fn(() => 'mockedURL');
+    global.URL.revokeObjectURL = jest.fn(); // Mocking revokeObjectURL too
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should get customDevices and suites from the store and download the file', () => {
+    const mockCustomDevices = [{ name: 'Device1', width: 800, height: 600 }];
+    const mockSuites = [{ name: 'Suite1' }];
+
+    const spyOnDownloadFileFn = jest.spyOn(Helpers, 'downloadFile');
+
+    (window.electron.store.get as jest.Mock).mockImplementation(
+      (key: string) => {
+        if (key === 'deviceManager.customDevices') {
+          return mockCustomDevices;
+        }
+        if (key === 'deviceManager.previewSuites') {
+          return mockSuites;
+        }
+        return null;
+      }
+    );
+
+    Helpers.onFileDownload();
+
+    expect(window.electron.store.get).toHaveBeenCalledWith(
+      'deviceManager.customDevices'
+    );
+    expect(window.electron.store.get).toHaveBeenCalledWith(
+      'deviceManager.previewSuites'
+    );
+    expect(spyOnDownloadFileFn).toHaveBeenCalledWith({
+      customDevices: mockCustomDevices,
+      suites: mockSuites,
+    });
+  });
+});
+
+describe('downloadFile', () => {
+  it('should create and download a JSON file', () => {
+    const mockFileData = { key: 'value' };
+    const mockedUrl = 'http://localhost/#';
+
+    const createObjectURLSpy = jest
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue(mockedUrl);
+    const revokeObjectURLSpy = jest.spyOn(URL, 'revokeObjectURL');
+    const spyOnDownloadFileFn = jest.spyOn(Helpers, 'downloadFile');
+
+    const { getByTestId } = render(
+      <div>
+        <Button
+          onClick={() => Helpers.downloadFile(mockFileData)}
+          data-testid="mockDownloadBtn"
+        >
+          Download
+        </Button>
+      </div>
+    );
+
+    const link = getByTestId('mockDownloadBtn');
+    fireEvent.click(link);
+
+    expect(spyOnDownloadFileFn).toHaveBeenCalled();
+    expect(createObjectURLSpy).toHaveBeenCalledWith(expect.any(Blob));
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(mockedUrl);
+  });
+});
+
+describe('setCustomDevices', () => {
+  it('should filter out default devices and store custom devices', () => {
+    const mockCustomDevices: Device[] = [
+      {
+        name: 'Device1',
+        width: 800,
+        height: 600,
+        id: '1',
+        userAgent: '',
+        type: '',
+        dpi: 0,
+        isTouchCapable: false,
+        isMobileCapable: false,
+        capabilities: [],
+      },
+      {
+        name: 'Device2',
+        width: 1024,
+        height: 768,
+        id: '2',
+        userAgent: '',
+        type: '',
+        dpi: 0,
+        isTouchCapable: false,
+        isMobileCapable: false,
+        capabilities: [],
+      },
+    ];
+
+    const mockDefaultDevices: Device[] = [
+      {
+        name: 'Device1',
+        width: 800,
+        height: 600,
+        id: '0',
+        userAgent: '',
+        type: '',
+        dpi: 0,
+        isTouchCapable: false,
+        isMobileCapable: false,
+        capabilities: [],
+      },
+    ];
+
+    jest.mock('common/deviceList', () => ({
+      defaultDevices: mockDefaultDevices,
+    }));
+
+    const filteredDevices = Helpers.setCustomDevices(mockCustomDevices);
+
+    expect(window.electron.store.set).not.toHaveBeenCalledWith(
+      'deviceManager.customDevices',
+      [mockCustomDevices[1]]
+    );
+
+    expect(filteredDevices).toEqual(mockCustomDevices);
+  });
+});

--- a/desktop-app/src/renderer/components/FileUploader/FileUploader.tsx
+++ b/desktop-app/src/renderer/components/FileUploader/FileUploader.tsx
@@ -26,7 +26,7 @@ export const FileUploader = ({
   }, [handleFileUpload, resetUploadedFile, uploadedFile]);
 
   return (
-    <div className="flex flex-row flex-wrap">
+    <div className="flex flex-row flex-wrap" data-testid="file-uploader">
       <input
         ref={fileInputRef}
         type="file"


### PR DESCRIPTION
### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; --> 

### ℹ️ About the PR
This PR does the following:
- extracts jest config from the package.json
- adds global mocks for electron and intersection obserer so components can be tested more easily.
- adds the command `yarn test:watch yourfile.test.tsx` -> it watches the test so when you save it runs it again automatically 
- adds the command `yarn test:coverage yourfolder/` -> it checks what lines are lacking test coverage in which files
- adds missing tests for the settings import/export feature, button and some other utils

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->
# ✨ Pull Request
Extract jest config and add it to the script. It also adds yarn `test:watch` to watch files while developing tests.
Usage: `yarn test:watch desktop-app/src/renderer/components/DeviceManager/PreviewSuites/ManageSuitesTool/utils.test.ts`


### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->
![Screenshot 2024-08-03 at 15 10 57](https://github.com/user-attachments/assets/ae171079-4bdb-4b6a-b988-7ef20c25ccd7)

