### PR TITLE
Selecting entire url for search bar

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -266,6 +266,11 @@ const AddressBar = () => {
               setIsSuggesting(false);
             }, 100);
           }}
+          onClick={() => {
+            setTimeout(() => {
+              inputRef.current?.select();
+            }, 0);
+          }}
         />
         <div
           className={`${


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

#1272 

### ℹ️ About the PR

To enhance the user experience, improved the behavior of the search bar by having it just like other browsers, when selected address bar, the entire url is highlighted rather than just showing the cursor at the end. This allows quicker switching between apps and sites.

### 🖼️ Testing Scenarios / Screenshots

![select_entire_url](https://github.com/user-attachments/assets/2702dbbb-7b22-4022-88d4-eba1ec59e388)

