### PR TITLE
Selecting the url in searchbar when clicked first

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -40,6 +40,7 @@ const AddressBar = () => {
   const [homepage, setHomepage] = useState<string>(
     window.electron.store.get('homepage')
   );
+  const [isFocused, setIsFocused] = useState(false);
   const [deleteStorageLoading, setDeleteStorageLoading] =
     useState<boolean>(false);
   const [deleteCookiesLoading, setDeleteCookiesLoading] =
@@ -262,9 +263,16 @@ const AddressBar = () => {
           onChange={(e) => setTypedAddress(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => {
+            setIsFocused(false);
             setTimeout(() => {
               setIsSuggesting(false);
             }, 100);
+          }}
+          onSelect={(e) => {
+            if (e.target === inputRef.current && !isFocused) {
+              inputRef.current?.select();
+              setIsFocused(true);
+            }
           }}
         />
         <div


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
#1272 

### ℹ️ About the PR

This pull request addresses the issue where clicking on the search bar in the Responsively App only places the cursor at the clicked position instead of selecting the entire URL. The update ensures that clicking the search bar will now select the entire URL.

### 🖼️ Testing Scenarios / Screenshots

https://github.com/user-attachments/assets/b2bd8fd5-892b-4965-b636-129f82d50335