### PR TITLE
Some new devices added to devicelist.ts

### DIFF
--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -455,6 +455,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '20016',
+    name: 'Pixel 7',
+    width: 412,
+    height: 915,
+    dpr: 2.625,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '30001',
     name: 'Samsung Galaxy S8+',
     width: 360,
@@ -676,6 +689,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '30018',
+    name: 'Galaxy Z Fold 5',
+    width: 344,
+    height: 882,
+    dpr: 1,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 13; SM-F946B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.131 Mobile Safari/537.36',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '40001',
     name: 'Nokia Lumia 520',
     width: 320,
@@ -872,45 +898,17 @@ export const defaultDevices: Device[] = [
   },
   {
     id: '90004',
-    name: 'Galaxy Z Fold 5',
-    width: 344,
-    height: 882,
-    dpr: 1,
-    capabilities: ['touch', 'mobile'],
+    name: 'Asus Zenbook Fold',
+    width: 853,
+    height: 1280,
+    dpr: 2,
+    capabilities: ['touch', 'tablet'],
     userAgent:
-      'Mozilla/5.0 (Linux; Android 13; SM-F946B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.131 Mobile Safari/537.36',
-    type: 'phone',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36',
+    type: 'tablet',
     isTouchCapable: true,
-    isMobileCapable: true,
-},
-{
-  id: '90005',
-  name: 'Asus Zenbook Fold',
-  width: 853,
-  height: 1280,
-  dpr: 2,
-  capabilities: ['touch', 'tablet'],
-  userAgent:
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36',
-  type: 'tablet',
-  isTouchCapable: true,
-  isMobileCapable: false,
-},
-{
-  id: '90006',
-  name: 'Pixel 7',
-  width: 412,
-  height: 915,
-  dpr: 2.625, 
-  capabilities: ['touch', 'mobile'],
-  userAgent:
-    'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36',
-  type: 'phone',
-  isTouchCapable: true,
-  isMobileCapable: true,
-},
-
-
+    isMobileCapable: false,
+  },
 ];
 
 const customDevices: () => Device[] = () => {

--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -870,6 +870,47 @@ export const defaultDevices: Device[] = [
     isTouchCapable: false,
     isMobileCapable: false,
   },
+  {
+    id: '90004',
+    name: 'Galaxy Z Fold 5',
+    width: 344,
+    height: 882,
+    dpr: 1,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 13; SM-F946B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.131 Mobile Safari/537.36',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+},
+{
+  id: '90005',
+  name: 'Asus Zenbook Fold',
+  width: 853,
+  height: 1280,
+  dpr: 2,
+  capabilities: ['touch', 'tablet'],
+  userAgent:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36',
+  type: 'tablet',
+  isTouchCapable: true,
+  isMobileCapable: false,
+},
+{
+  id: '90006',
+  name: 'Pixel 7',
+  width: 412,
+  height: 915,
+  dpr: 2.625, 
+  capabilities: ['touch', 'mobile'],
+  userAgent:
+    'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36',
+  type: 'phone',
+  isTouchCapable: true,
+  isMobileCapable: true,
+},
+
+
 ];
 
 const customDevices: () => Device[] = () => {


### PR DESCRIPTION
# ✨ Pull Request

### ℹ️ About the PR

This PR introduces the following updates to the devicelist.ts:

1.Added support for Galaxy Z Fold 5 with a screen size of 344x882, dpr: 1.
2.Added support for Asus Zenbook Fold with a screen size of 853x1280, dpr: 2.
3.Added support for Pixel 7 with a screen size of 412x915, dpr: 2.625.

Each device entry includes its specific properties like userAgent, capabilities, and device type (phone, tablet).

### 🖼️ Testing Scenarios / Screenshots

Tested the changes by simulating these devices in the responsive design mode of Google Chrome DevTools.
Verified touch and mobile capabilities for the Galaxy Z Fold 5 and Pixel 7.
Ensured that the Asus Zenbook Fold is categorized as a tablet with the appropriate touch capabilities.
