### PR TITLE
Update Roadmap to desktop link that is not working  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ If you face any problems while using the application, please open an issue here 
 
 ## Roadmap
 
-Here is the roadmap of the desktop app - https://github.com/responsively-org/responsively-app/projects/12?fullscreen=true.
-
+Here is the roadmap of the desktop app - https://github.com/responsively-org/responsively-app/projects/
 ## Gold sponsors 🥇
 
 <p>&nbsp;</p>


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1302

### ℹ️ About the PR

The desktop app link was not working because there was no project at https://github.com/responsively-org/responsively-app/projects/12?fullscreen=true. So, I have directly redirected the user to https://github.com/responsively-org/responsively-app/projects instead.

### 🖼️ Testing Scenarios / Screenshots

Before 
<img width="1465" alt="Screenshot 2024-09-14 at 2 31 32 PM" src="https://github.com/user-attachments/assets/e86cb8d5-c26c-4725-bb75-a7f2e818ad6a">

After 
<img width="1470" alt="Screenshot 2024-09-14 at 2 16 09 PM" src="https://github.com/user-attachments/assets/dfe66d83-276d-4dce-936e-293d5eb8be60">

