### PR TITLE
 Fix for issue #1322 : Changed the media query for better margin and …

### DIFF
--- a/desktop-app-legacy/app/components/WebView/style.module.css
+++ b/desktop-app-legacy/app/components/WebView/style.module.css
@@ -121,3 +121,59 @@
 .withMarginRight {
   margin-right: 5rem;
 }
+
+/* For tablets (iPad Mini, iPad Pro, general tablet size) */
+@media (max-width: 1024px) {
+  .webViewContainer {
+    min-width: 150px;
+  }
+  .webViewToolbar {
+    margin: 5px 2px;
+    flex-direction: column;
+  }
+  .webViewToolbarIcons {
+    height: 25px;
+    width: 25px;
+  }
+  .resizableView {
+    margin: 0 0.5rem 0.5rem 0;
+  }
+}
+
+/* For mobile devices (iPhone X, iPhone 14 Pro) */
+@media (max-width: 768px) {
+  .webViewContainer {
+    min-width: 120px;
+  }
+  .webViewToolbar {
+    margin: 3px 1px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .webViewToolbarIcons {
+    height: 20px;
+    width: 20px;
+  }
+  .resizableView {
+    margin: 0 0.25rem 0.25rem 0;
+  }
+}
+
+/* For small screens */
+@media (max-width: 480px) {
+  .webViewContainer {
+    min-width: 100px;
+  }
+  .webViewToolbar {
+    margin: 2px 1px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .webViewToolbarIcons {
+    height: 18px;
+    width: 18px;
+  }
+  .resizableView {
+    margin: 0 0.25rem 0.25rem 0;
+  }
+}


### PR DESCRIPTION
…padding to add a responsiveness

# ✨ Pull Request

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->

### ℹ️ About the PR

This PR addresses the responsiveness issues in the layout by incorporating media queries to adjust the dimensions and alignment of various elements such as .webViewToolbar, .webViewToolbarIcons, and .resizableView. The changes ensure that the layout adapts appropriately across devices including tablets, mobile phones, and smaller screens.

Specifically:

Implemented media queries for breakpoints at 1024px, 768px, and 480px to optimize the display for tablets, mobile, and very small screens.
Reduced icon sizes and adjusted margins for toolbar elements in smaller screen sizes.
Changed the flex direction of the toolbar on smaller screens for better vertical stacking of elements.
No breaking changes are introduced, and the code remains backwards-compatible with larger desktop screens.

### 🖼️ Testing Scenarios / Screenshots

Desktop (screen width > 1024px): No changes to the original layout, all elements remain as expected.
Tablet (screen width ~768px): Toolbar elements are resized, margins are adjusted, and the layout is adapted to a smaller screen.
Mobile (screen width ~480px): Toolbar flex-direction changes to the column for vertical stacking, icons shrink, and margins reduced to fit the smaller screen.
