### PR TITLE
fix: Fix restricted device size to enable phones landscape

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -72,7 +72,7 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
   const [singleRotated, setSingleRotated] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ErrorState | null>(null);
-  const [screenshotInProgress, setScreenshotInProgess] =
+  const [screenshotInProgress, setScreenshotInProgress] =
     useState<boolean>(false);
   const address = useSelector(selectAddress);
   const zoomfactor = useSelector(selectZoomFactor);
@@ -497,10 +497,13 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
   const scaledHeight = height * zoomfactor;
   const scaledWidth = width * zoomfactor;
 
+  const isRestrictedMinimumDeviceSize =
+    device.width < 400 && zoomfactor < 0.6 && !rotateDevices && !singleRotated;
+
   return (
     <div
-      className={cx('h-fit flex-shrink-0', {
-        'w-52': device.width < 400 && zoomfactor < 0.6,
+      className={cx('h-fit', {
+        'w-52': isRestrictedMinimumDeviceSize,
       })}
     >
       <div className="flex justify-between">
@@ -515,7 +518,7 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
       <Toolbar
         webview={ref.current}
         device={device}
-        setScreenshotInProgress={setScreenshotInProgess}
+        setScreenshotInProgress={setScreenshotInProgress}
         openDevTools={openDevTools}
         toggleRuler={toggleRuler}
         onRotate={onRotateHandler}


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fix #1210

### ℹ️ About the PR

Added checker for landscape mode before strict ("w-52") size of device. 

flex-shrink-0 is not needed because we have control over elements with overflow scroll.

But long-term I'd put all the layout settings (incl. Masonry Layout, Preview Layout) into one component. Now it's too easy to break the whole visual configuration with inappropriate css style

### 🖼️ Testing Scenarios / Screenshots

<img width="1440" alt="Screenshot 2024-12-10 at 15 45 20" src="https://github.com/user-attachments/assets/cb47aa12-f800-46b0-836b-a3cdd637d16a">
<img width="1440" alt="Screenshot 2024-12-10 at 15 45 26" src="https://github.com/user-attachments/assets/7f015515-695d-4269-b1c6-9937370438c8">
<img width="1440" alt="Screenshot 2024-12-10 at 15 45 33" src="https://github.com/user-attachments/assets/0b341b06-2bbe-4216-9003-49eed378c96c">
<img width="1440" alt="Screenshot 2024-12-10 at 15 45 35" src="https://github.com/user-attachments/assets/c141d8b8-dc3e-485a-8d87-96c3389300c9">

