### PR TITLE
Add iMac 27" to device and update MacBook Pro name to add inch

### DIFF
--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -209,7 +209,7 @@ export const defaultDevices: Device[] = [
   },
   {
     id: '10015',
-    name: 'MacBook Pro',
+    name: 'MacBook Pro 15"',
     width: 1440,
     height: 900,
     dpr: 2,
@@ -336,6 +336,19 @@ export const defaultDevices: Device[] = [
     type: 'phone',
     isTouchCapable: true,
     isMobileCapable: true,
+  },
+  {
+    id: '10025',
+    name: 'iMac 27"',
+    width: 2560,
+    height: 1440,
+    dpr: 2,
+    capabilities: [],
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15',
+    type: 'desktop',
+    isTouchCapable: false,
+    isMobileCapable: false,
   },
   {
     id: '20001',


### PR DESCRIPTION
# ✨ Pull Request

### ℹ️ About the PR

I added iMac 27" to devices for super wide screen. and update MacBook Pro -> MacBook Pro 15" cause MacBook has deference pixels each year and inches. so, it may require for  devide.


### 🖼️ Testing Scenarios / Screenshots

<img width="2241" alt="스크린샷 2025-01-27 오후 8 29 08" src="https://github.com/user-attachments/assets/2c21d158-3ef5-45c4-8252-a50c41bad87b" />


