### PR TITLE
Add missing key attribute in ButtonGroup component

### DIFF
--- a/desktop-app/src/renderer/components/ButtonGroup/index.tsx
+++ b/desktop-app/src/renderer/components/ButtonGroup/index.tsx
@@ -16,6 +16,7 @@ export const ButtonGroup = ({ buttons }: Props) => {
       {buttons.map(({ content, srContent, onClick, isActive }, index) => (
         <button
           type="button"
+          key={srContent}
           className={cx(
             'relative inline-flex items-center px-2 py-2 text-slate-500 ring-1 ring-inset ring-slate-300 hover:bg-slate-300 focus:z-10 dark:text-slate-200 hover:dark:bg-slate-600',
             {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue
-

### ℹ️ About the PR
Key attribute was missing from button in ButtonGroup component. 
This PR added the prop srContent as a key for buttons in the component.

### 🖼️ Testing Scenarios / Screenshots
-