### PR TITLE
fix: prevent crash on reload when window/webContents destroyed (#1380)

### DIFF
--- a/desktop-app/src/main/menu/view.ts
+++ b/desktop-app/src/main/menu/view.ts
@@ -30,11 +30,18 @@ const getReloadMenu = (
   label: '&Reload',
   accelerator: 'CommandOrControl+R',
   click: () => {
-    if (isDev) {
-      mainWindow.webContents.reload();
-      return;
+    if (
+      mainWindow &&
+      !mainWindow.isDestroyed() &&
+      mainWindow.webContents &&
+      !mainWindow.webContents.isDestroyed()
+    ) {
+      if (isDev) {
+        mainWindow.webContents.reload();
+      } else {
+        mainWindow.webContents.send('reload', {});
+      }
     }
-    mainWindow.webContents.send('reload', {});
   },
 });
 
@@ -44,7 +51,14 @@ const getReloadIgnoringCacheMenu = (
   label: 'Reload Ignoring Cache',
   accelerator: 'CommandOrControl+Shift+R',
   click: () => {
-    mainWindow.webContents.send('reload', { ignoreCache: true });
+    if (
+      mainWindow &&
+      !mainWindow.isDestroyed() &&
+      mainWindow.webContents &&
+      !mainWindow.webContents.isDestroyed()
+    ) {
+      mainWindow.webContents.send('reload', { ignoreCache: true });
+    }
   },
 });
 


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1380

### ℹ️ About the PR

This PR adds a defensive check before triggering a reload action in the Electron menu handler to prevent a crash when the window or its webContents are already destroyed.

- This bug mainly affects macOS (Command+R / View > Reload), where the user could receive a TypeError: Object has been destroyed error if the reload shortcut/menu is used in certain states.

- The fix checks mainWindow and mainWindow.webContents for existence and not being destroyed before calling .reload() or sending the reload event.

- This follows best practices for Electron apps, and keeps behavior unchanged for unaffected platforms (e.g., Windows).

### 🖼️ Testing Scenarios / Screenshots

- On Windows, Ctrl+R and View > Reload continue to work as expected, and no errors are thrown.

- While the original crash was reported on macOS, this change should prevent the uncaught exception for all platforms.

- Please confirm on macOS that the bug is resolved.
