### PR TITLE
 chore: add iphone 11 device specs

### DIFF
--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -338,6 +338,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '10025',
+    name: 'iPhone 11',
+    width: 414,
+    height: 896,
+    dpr: 2,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.79 Mobile/15E148 Safari/604.1',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '20001',
     name: 'Nexus 4',
     width: 384,


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

There is no specific issue that directly prompted this PR.


### ℹ️ About the PR

This PR adds a new device to the device list—iPhone 11—with the following properties:

- ID: 10025
- Name: iPhone 11
- Width: 414px
- Height: 896px
- DPR: 2
- Capabilities: touch, mobile
- User Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.79 Mobile/15E148 Safari/604.1
- Device Type: phone
- Is Touch Capable: true
- Is Mobile Capable: true
- 
This device was added to improve the testing and support for different iPhone versions in mobile-friendly applications.

### 🖼️ Testing Scenarios / Screenshots

Test Scenario: After adding the iPhone 11 to the device list, verify that the new device configuration properly matches the expected behavior in the UI, especially for mobile-specific interactions.

Screenshots: 
<img width="611" height="907" alt="Screenshot 2025-07-30 101406" src="https://github.com/user-attachments/assets/d958023e-c445-4c42-a4cd-7aa4bf6e5531" />

