### PR TITLE
Added max-height property to make the dropdown content scrollable

### DIFF
--- a/desktop-app/src/renderer/components/DropDown/index.tsx
+++ b/desktop-app/src/renderer/components/DropDown/index.tsx
@@ -40,7 +40,7 @@ export function DropDown({ label, options, className }: Props) {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Menu.Items className="z-50 mt-2 w-fit origin-top-right divide-y divide-slate-100 rounded-md bg-slate-100 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900">
+            <Menu.Items className="z-50 mt-2 max-h-80 w-fit origin-top-right divide-y divide-slate-100 overflow-y-auto rounded-md bg-slate-100 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900">
               <div className="px-1 py-1 ">
                 {options.map((option, idx) => {
                   if (option.type === 'separator') {


### PR DESCRIPTION
Fixes #1387

# ✨ Pull Request

### 📓 Referenced Issue

- Fixes https://github.com/responsively-org/responsively-app/issues/1387

### ℹ️ About the PR

This PR modified the `Dropdown content styles`, adding a max-height for create the content scrollable.

- Why max-h-80?
  - I rater use a fixed value instead of a dynamic heighit property.
  - Using dynamic height properties can cause bugs.

### 🖼️ Testing Scenarios / Screenshots

<img width="2045" height="918" alt="image" src="https://github.com/user-attachments/assets/636498ab-d2a7-45a3-a5ca-e4d79e8e561d" />

<img width="2044" height="919" alt="image" src="https://github.com/user-attachments/assets/0304ef32-3b31-4226-b101-2d922935162e" />


