### PR TITLE
Added New iPhone 17 Versions

### DIFF
--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -337,7 +337,7 @@ export const defaultDevices: Device[] = [
     isTouchCapable: true,
     isMobileCapable: true,
   },
-
+  // new option added
   {
     id: '10025',
     name: 'iPhone 17',

--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -365,6 +365,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '10027',
+    name: 'iPhone 17 Pro Max',
+    width: 430,
+    height: 932,
+    dpr: 3,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '20001',
     name: 'Nexus 4',
     width: 384,

--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -378,6 +378,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '10028',
+    name: 'iPhone 17 Air',
+    width: 428,
+    height: 926,
+    dpr: 3,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '20001',
     name: 'Nexus 4',
     width: 384,

--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -352,6 +352,19 @@ export const defaultDevices: Device[] = [
     isMobileCapable: true,
   },
   {
+    id: '10026',
+    name: 'iPhone 17 Pro',
+    width: 393,
+    height: 852,
+    dpr: 3,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
+  {
     id: '20001',
     name: 'Nexus 4',
     width: 384,

--- a/desktop-app/src/common/deviceList.ts
+++ b/desktop-app/src/common/deviceList.ts
@@ -337,6 +337,20 @@ export const defaultDevices: Device[] = [
     isTouchCapable: true,
     isMobileCapable: true,
   },
+
+  {
+    id: '10025',
+    name: 'iPhone 17',
+    width: 393,
+    height: 852,
+    dpr: 3,
+    capabilities: ['touch', 'mobile'],
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+    type: 'phone',
+    isTouchCapable: true,
+    isMobileCapable: true,
+  },
   {
     id: '20001',
     name: 'Nexus 4',


### PR DESCRIPTION
Pull Request: Added iPhone 17 Models to Device List

Fix: #1419 
ℹ️ About the PR
This PR adds the anticipated iPhone 17 models to the device list based on industry projections and Apple's typical release patterns. The implementation includes:

⭐Four new iPhone 17 models: iPhone 17, iPhone 17 air, iPhone 17 Pro, and iPhone 17 Pro Max


The implementation follows the existing pattern in the codebase while adding future-looking device specifications that will help developers test their responsive designs against anticipated screen sizes.

Testing Performed and Passed✅

Screenshot of new devices:

<img width="1051" height="694" alt="Iphone 17vrsns" src="https://github.com/user-attachments/assets/57040aa2-4012-40d0-b62c-92609d63c662" />


