### PR TITLE
add: added detailed site permissions in the address bar

### DIFF
--- a/desktop-app/src/common/constants.ts
+++ b/desktop-app/src/common/constants.ts
@@ -38,8 +38,33 @@ export const IPC_MAIN_CHANNELS = {
   START_WATCHING_FILE: 'start-watching-file',
   STOP_WATCHER: 'stop-watcher',
   OPEN_ABOUT_DIALOG: 'open-about-dialog',
+  GET_SITE_PERMISSIONS: 'get-site-permissions',
+  UPDATE_SITE_PERMISSION: 'update-site-permission',
+  CLEAR_SITE_PERMISSIONS: 'clear-site-permissions',
+  PERMISSION_UPDATED: 'permission-updated',
 } as const;
 
 export type Channels = typeof IPC_MAIN_CHANNELS[keyof typeof IPC_MAIN_CHANNELS];
 
 export const PROTOCOL = 'responsively';
+
+export const PERMISSION_TYPES = {
+  CAMERA: 'camera',
+  MICROPHONE: 'microphone',
+  LOCATION: 'geolocation',
+  NOTIFICATIONS: 'notifications',
+  CLIPBOARD: 'clipboard-read',
+  FULLSCREEN: 'fullscreen',
+  MIDI: 'midi',
+  POINTER_LOCK: 'pointerLock',
+} as const;
+
+export type PermissionType =
+  typeof PERMISSION_TYPES[keyof typeof PERMISSION_TYPES];
+
+export interface SitePermission {
+  type: string;
+  state: 'GRANTED' | 'DENIED' | 'PROMPT' | 'UNKNOWN';
+  displayName: string;
+  icon: string;
+}

--- a/desktop-app/src/main/preload-webview.ts
+++ b/desktop-app/src/main/preload-webview.ts
@@ -24,6 +24,28 @@ const documentBodyInit = () => {
     });
   });
 
+  // Handle F key for fullscreen toggle
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'f' || e.key === 'F') {
+      e.preventDefault();
+
+      // Check if already in fullscreen
+      if (document.fullscreenElement) {
+        // Exit fullscreen
+        document.exitFullscreen().catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('Error exiting fullscreen:', err);
+        });
+      } else {
+        // Request fullscreen
+        document.documentElement.requestFullscreen().catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('Error requesting fullscreen:', err);
+        });
+      }
+    }
+  });
+
   window.addEventListener('dom-ready', () => {
     const { body } = document;
     const html = document.documentElement;

--- a/desktop-app/src/main/web-permissions/PermissionsManager.ts
+++ b/desktop-app/src/main/web-permissions/PermissionsManager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, ipcMain, session } from 'electron';
 import { IPC_MAIN_CHANNELS } from '../../common/constants';
 import store from '../../store';
 
@@ -58,7 +58,7 @@ const savePermissions = (permissions: Record<string, PermissionRecords>) => {
       return {
         origin,
         permissions: Object.entries(permissionRecords)
-          .filter(([_, status]) => {
+          .filter(([, status]) => {
             return (
               status === PERMISSION_STATE.GRANTED ||
               status === PERMISSION_STATE.DENIED
@@ -109,6 +109,7 @@ class PermissionsManager {
         ipcMain.handle(PERMISSION_RESPONSE_CHANNEL, handler);
       } catch (e) {
         // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console
         console.error(
           'Error adding listener for permission response channel',
           e
@@ -132,6 +133,12 @@ class PermissionsManager {
       };
     }
     savePermissions(this.permissions);
+
+    this.mainWindow.webContents.send(IPC_MAIN_CHANNELS.PERMISSION_UPDATED, {
+      origin,
+      type,
+      state,
+    });
   }
 
   requestPermission(
@@ -140,32 +147,117 @@ class PermissionsManager {
     callback: PermissionCallback
   ): void {
     this.permissions[origin] = this.permissions[origin] || {};
-    const previousState = this.permissions[origin][type];
-    if (previousState !== PERMISSION_STATE.GRANTED) {
-      this.permissions[origin][type] = PERMISSION_STATE.PROMPT;
-    }
+    const currentState = this.permissions[origin][type];
+
     const key = `${origin}-${type}`;
     let callbacks = this.callbacks[key];
     if (callbacks === undefined) {
       callbacks = [];
       this.callbacks[key] = callbacks;
     }
-    if (previousState === PERMISSION_STATE.GRANTED) {
+
+    // If permission is explicitly granted, allow immediately
+    if (currentState === PERMISSION_STATE.GRANTED) {
       callback(true);
       return;
     }
-    if (previousState === PERMISSION_STATE.DENIED) {
+
+    // If permission is explicitly denied, block immediately
+    if (currentState === PERMISSION_STATE.DENIED) {
       callback(false);
       return;
     }
-    callbacks.push(callback);
-    if (previousState === PERMISSION_STATE.PROMPT) {
-      return;
+
+    // For PROMPT or UNKNOWN states, show permission dialog
+    // Set to PROMPT state to indicate it's requesting
+    if (currentState !== PERMISSION_STATE.PROMPT) {
+      this.permissions[origin][type] = PERMISSION_STATE.PROMPT;
     }
-    this.mainWindow.webContents.send(IPC_MAIN_CHANNELS.PERMISSION_REQUEST, {
-      permission: type,
-      requestingOrigin: origin,
-    });
+
+    callbacks.push(callback);
+
+    // Only show dialog if no other requests are pending for this permission
+    if (callbacks.length === 1) {
+      this.mainWindow.webContents.send(IPC_MAIN_CHANNELS.PERMISSION_REQUEST, {
+        permission: type,
+        requestingOrigin: origin,
+      });
+    }
+  }
+
+  getSitePermissions(origin: string) {
+    const permissions = this.permissions[origin] || {};
+    const commonPermissions = [
+      { type: 'camera', displayName: 'Camera', icon: 'mdi:camera' },
+      { type: 'microphone', displayName: 'Microphone', icon: 'mdi:microphone' },
+      { type: 'geolocation', displayName: 'Location', icon: 'mdi:map-marker' },
+      { type: 'notifications', displayName: 'Notifications', icon: 'mdi:bell' },
+      {
+        type: 'clipboard-read',
+        displayName: 'Clipboard',
+        icon: 'mdi:content-paste',
+      },
+      { type: 'fullscreen', displayName: 'Fullscreen', icon: 'mdi:fullscreen' },
+      { type: 'midi', displayName: 'MIDI Devices', icon: 'mdi:piano' },
+      {
+        type: 'pointerLock',
+        displayName: 'Pointer Lock',
+        icon: 'mdi:cursor-move',
+      },
+    ];
+
+    return commonPermissions.map((permission) => ({
+      ...permission,
+      state: permissions[permission.type] || PERMISSION_STATE.UNKNOWN,
+    }));
+  }
+
+  updateSitePermission(origin: string, type: string, state: PermissionState) {
+    // If changing to PROMPT state, clear any cached permission decisions in the session
+    if (state === PERMISSION_STATE.PROMPT) {
+      // Clear storage data for this origin to ensure fresh permission requests
+      session.defaultSession
+        .clearStorageData({
+          origin,
+          storages: [],
+          quotas: [],
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Failed to clear storage data for origin:', origin, e);
+        });
+    }
+
+    this.setPermissionState(origin, type, state);
+  }
+
+  clearSitePermissions(origin: string) {
+    const permissions = this.permissions[origin];
+    if (permissions) {
+      // Clear storage data for this origin to ensure fresh permission requests
+      session.defaultSession
+        .clearStorageData({
+          origin,
+          storages: [],
+          quotas: [],
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Failed to clear storage data for origin:', origin, e);
+        });
+
+      // Notify about each permission being cleared (reset to UNKNOWN)
+      Object.keys(permissions).forEach((type) => {
+        this.mainWindow.webContents.send(IPC_MAIN_CHANNELS.PERMISSION_UPDATED, {
+          origin,
+          type,
+          state: PERMISSION_STATE.UNKNOWN,
+        });
+      });
+    }
+
+    delete this.permissions[origin];
+    savePermissions(this.permissions);
   }
 }
 

--- a/desktop-app/src/main/web-permissions/index.ts
+++ b/desktop-app/src/main/web-permissions/index.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, session } from 'electron';
+import { BrowserWindow, session, ipcMain } from 'electron';
 import PermissionsManager, { PERMISSION_STATE } from './PermissionsManager';
+import { IPC_MAIN_CHANNELS } from '../../common/constants';
 import store from '../../store';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -41,6 +42,41 @@ export const WebPermissionHandlers = (mainWindow: BrowserWindow) => {
             );
           }
           callback({ requestHeaders: details.requestHeaders });
+        }
+      );
+
+      // Add IPC handlers for site permissions management
+      ipcMain.handle(
+        IPC_MAIN_CHANNELS.GET_SITE_PERMISSIONS,
+        (_event, origin: string) => {
+          return permissionsManager.getSitePermissions(origin);
+        }
+      );
+
+      ipcMain.handle(
+        IPC_MAIN_CHANNELS.UPDATE_SITE_PERMISSION,
+        (
+          _event,
+          {
+            origin,
+            type,
+            state,
+          }: { origin: string; type: string; state: string }
+        ) => {
+          permissionsManager.updateSitePermission(
+            origin,
+            type,
+            state as typeof PERMISSION_STATE[keyof typeof PERMISSION_STATE]
+          );
+          return true;
+        }
+      );
+
+      ipcMain.handle(
+        IPC_MAIN_CHANNELS.CLEAR_SITE_PERMISSIONS,
+        (_event, origin: string) => {
+          permissionsManager.clearSitePermissions(origin);
+          return true;
         }
       );
     },

--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/SitePermissions/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/SitePermissions/index.tsx
@@ -1,0 +1,359 @@
+import { Icon } from '@iconify/react';
+import { useState, useEffect, useRef } from 'react';
+import { IPC_MAIN_CHANNELS, SitePermission } from 'common/constants';
+import { webViewPubSub } from 'renderer/lib/pubsub';
+import { NAVIGATION_EVENTS } from 'renderer/components/ToolBar/NavigationControls';
+
+const PERMISSION_STATES = {
+  GRANTED: 'GRANTED',
+  DENIED: 'DENIED',
+  PROMPT: 'PROMPT',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+interface SitePermissionsDropdownProps {
+  currentAddress: string;
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+interface PermissionToggleProps {
+  permission: SitePermission;
+  onToggle: (type: string, state: string) => void;
+}
+
+const PermissionToggle = ({ permission, onToggle }: PermissionToggleProps) => {
+  const getStateDisplay = (state: string) => {
+    switch (state) {
+      case PERMISSION_STATES.GRANTED:
+        return {
+          text: 'Allow',
+          color: 'text-green-600 dark:text-green-400',
+          icon: 'mdi:check-circle',
+        };
+      case PERMISSION_STATES.DENIED:
+        return {
+          text: 'Block',
+          color: 'text-red-600 dark:text-red-400',
+          icon: 'mdi:block-helper',
+        };
+      default:
+        return {
+          text: 'Ask',
+          color: 'text-gray-600 dark:text-gray-400',
+          icon: 'mdi:help-circle',
+        };
+    }
+  };
+
+  const cycleState = () => {
+    const states = [
+      PERMISSION_STATES.UNKNOWN,
+      PERMISSION_STATES.GRANTED,
+      PERMISSION_STATES.DENIED,
+    ];
+    const currentIndex = states.findIndex(
+      (state) => state === permission.state
+    );
+    const nextIndex = (currentIndex + 1) % states.length;
+    onToggle(permission.type, states[nextIndex]);
+  };
+
+  const display = getStateDisplay(permission.state);
+
+  return (
+    <div className="flex items-center justify-between rounded py-2 px-2 hover:bg-gray-100 dark:hover:bg-slate-700">
+      <div className="flex items-center gap-2">
+        <Icon icon={permission.icon} className="text-sm" />
+        <span className="text-xs">{permission.displayName}</span>
+      </div>
+      <button
+        type="button"
+        onClick={cycleState}
+        className={`flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium transition-colors hover:bg-gray-200 dark:hover:bg-slate-600 ${display.color}`}
+      >
+        <Icon icon={display.icon} className="text-xs" />
+        {display.text}
+      </button>
+    </div>
+  );
+};
+
+const SitePermissionsDropdown = ({
+  currentAddress,
+  isVisible,
+  onClose,
+}: SitePermissionsDropdownProps) => {
+  const [sitePermissions, setSitePermissions] = useState<SitePermission[]>([]);
+  const [origin, setOrigin] = useState<string>('');
+  const [showRefreshNotification, setShowRefreshNotification] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    if (isVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isVisible, onClose]);
+
+  const refreshPage = async () => {
+    if (isRefreshing) return;
+
+    setIsRefreshing(true);
+    try {
+      // Use the webview pubsub system to reload all webviews
+      webViewPubSub.publish(NAVIGATION_EVENTS.RELOAD);
+
+      // Hide refresh notification after a brief delay
+      setTimeout(() => {
+        setShowRefreshNotification(false);
+        setIsRefreshing(false);
+      }, 2000);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to refresh page:', error);
+      setIsRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    const getOriginFromUrl = (url: string) => {
+      try {
+        if (url.startsWith('file://')) return 'Local File';
+        const urlObj = new URL(url);
+        return urlObj.origin;
+      } catch {
+        return 'Invalid URL';
+      }
+    };
+
+    const currentOrigin = getOriginFromUrl(currentAddress);
+    setOrigin(currentOrigin);
+
+    const loadSitePermissions = async () => {
+      if (
+        currentOrigin &&
+        currentOrigin !== 'Local File' &&
+        currentOrigin !== 'Invalid URL'
+      ) {
+        try {
+          const permissions = (await window.electron.ipcRenderer.invoke(
+            IPC_MAIN_CHANNELS.GET_SITE_PERMISSIONS,
+            currentOrigin
+          )) as SitePermission[];
+          setSitePermissions(permissions);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to load site permissions:', error);
+          setSitePermissions([]);
+        }
+      } else {
+        setSitePermissions([]);
+      }
+    };
+
+    if (isVisible) {
+      loadSitePermissions();
+    }
+  }, [currentAddress, isVisible]);
+
+  // Listen for permission updates from the main process
+  useEffect(() => {
+    const handlePermissionUpdate = (args: {
+      origin: string;
+      type: string;
+      state: string;
+    }) => {
+      // Only update if it's for the current origin
+      if (args.origin === origin) {
+        setSitePermissions((prev) =>
+          prev.map((p) =>
+            p.type === args.type
+              ? { ...p, state: args.state as SitePermission['state'] }
+              : p
+          )
+        );
+
+        // Show refresh notification when permission changes
+        setShowRefreshNotification(true);
+      }
+    };
+
+    window.electron.ipcRenderer.on(
+      IPC_MAIN_CHANNELS.PERMISSION_UPDATED,
+      handlePermissionUpdate
+    );
+
+    return () => {
+      window.electron.ipcRenderer.removeListener(
+        IPC_MAIN_CHANNELS.PERMISSION_UPDATED,
+        handlePermissionUpdate
+      );
+    };
+  }, [origin]);
+
+  const handlePermissionToggle = async (type: string, state: string) => {
+    try {
+      await window.electron.ipcRenderer.invoke(
+        IPC_MAIN_CHANNELS.UPDATE_SITE_PERMISSION,
+        {
+          origin,
+          type,
+          state,
+        }
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to update permission:', error);
+    }
+  };
+
+  const handleClearAllPermissions = async () => {
+    try {
+      await window.electron.ipcRenderer.invoke(
+        IPC_MAIN_CHANNELS.CLEAR_SITE_PERMISSIONS,
+        origin
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to clear permissions:', error);
+    }
+  };
+
+  const hasActivePermissions = sitePermissions.some(
+    (p) =>
+      p.state === PERMISSION_STATES.GRANTED ||
+      p.state === PERMISSION_STATES.DENIED
+  );
+
+  if (!isVisible) return null;
+
+  if (!origin || origin === 'Local File' || origin === 'Invalid URL') {
+    return (
+      <div
+        ref={dropdownRef}
+        className="w-80 rounded-md bg-white p-4 shadow-lg ring-1 ring-slate-500 !ring-opacity-40 dark:bg-slate-900 dark:ring-white dark:!ring-opacity-40"
+      >
+        <div className="flex items-center gap-2 text-gray-500">
+          <Icon icon="mdi:shield-lock" />
+          <span className="text-sm">
+            Site permissions not available for this page
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={dropdownRef}
+      className="w-80 rounded-md bg-white shadow-lg ring-1 ring-slate-500 !ring-opacity-40 dark:bg-slate-900 dark:ring-white dark:!ring-opacity-40"
+    >
+      {/* Header */}
+      <div className="border-b border-gray-200 px-4 py-3 dark:border-slate-700">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Icon icon="mdi:shield-lock" className="text-lg" />
+            <span className="text-sm font-medium">Site Permissions</span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 hover:bg-gray-100 dark:hover:bg-slate-700"
+          >
+            <Icon icon="mdi:close" className="text-sm" />
+          </button>
+        </div>
+        <div className="mt-1 truncate text-xs text-gray-500" title={origin}>
+          {origin.replace(/^https?:\/\//, '')}
+        </div>
+      </div>
+
+      {/* Refresh Notification */}
+      {showRefreshNotification && (
+        <div className="mx-4 mt-3 mb-2 rounded border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-700 dark:bg-blue-900">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-300">
+              <Icon
+                icon={isRefreshing ? 'mdi:loading' : 'mdi:information'}
+                className={isRefreshing ? 'animate-spin' : ''}
+              />
+              <span className="text-xs">
+                {isRefreshing
+                  ? 'Refreshing page...'
+                  : 'Permission updated. Refresh to apply changes.'}
+              </span>
+            </div>
+            {!isRefreshing && (
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={refreshPage}
+                  className="rounded bg-blue-600 px-2 py-1 text-xs text-white transition-colors hover:bg-blue-700"
+                >
+                  Refresh
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowRefreshNotification(false)}
+                  className="rounded bg-gray-500 px-2 py-1 text-xs text-white transition-colors hover:bg-gray-600"
+                >
+                  ×
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Permissions List */}
+      <div className="px-4 py-3">
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+            Permissions for this site
+          </span>
+          {hasActivePermissions && (
+            <button
+              type="button"
+              onClick={handleClearAllPermissions}
+              className="text-xs text-red-600 hover:underline dark:text-red-400"
+              title="Reset all permissions to default"
+            >
+              Reset All
+            </button>
+          )}
+        </div>
+
+        <div className="max-h-64 space-y-1 overflow-y-auto">
+          {sitePermissions.map((permission) => (
+            <PermissionToggle
+              key={permission.type}
+              permission={permission}
+              onToggle={handlePermissionToggle}
+            />
+          ))}
+        </div>
+
+        <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          Changes take effect immediately. Reload the page if needed.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SitePermissionsDropdown;

--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -25,6 +25,7 @@ import useKeyboardShortcut, {
 import AuthModal from './AuthModal';
 import SuggestionList from './SuggestionList';
 import Bookmark from './BookmarkButton';
+import SitePermissionsDropdown from './SitePermissions';
 
 export const ADDRESS_BAR_EVENTS = {
   DELETE_COOKIES: 'DELETE_COOKIES',
@@ -49,6 +50,7 @@ const AddressBar = () => {
   const [permissionRequest, setPermissionRequest] =
     useState<PermissionRequestArg | null>(null);
   const [authRequest, setAuthRequest] = useState<AuthRequestArgs | null>(null);
+  const [showSitePermissions, setShowSitePermissions] = useState(false);
   const address = useSelector(selectAddress);
   const pageTitle = useSelector(selectPageTitle);
   const dispatch = useDispatch();
@@ -222,40 +224,56 @@ const AddressBar = () => {
         onDrop={handleDrop}
         className="relative z-10 w-full flex-grow"
       >
-        <div className="absolute top-2 left-2 mr-2 flex flex-col items-start">
-          <Icon icon="mdi:web" className="text-gray-500" />
-          {permissionRequest != null ? (
-            <div className="z-40 mt-4 flex w-96 flex-col gap-8 rounded bg-white p-6 shadow-lg ring-1 ring-slate-500 !ring-opacity-40 focus:outline-none dark:bg-slate-900 dark:ring-white dark:!ring-opacity-40">
-              <span>
-                {permissionRequest.requestingOrigin} requests permission for:{' '}
-                <br />
-                <span className="flex justify-center font-bold capitalize">
-                  {permissionRequest.permission}
-                </span>
+        <div className="absolute inset-y-0 left-2 flex items-center">
+          <button
+            type="button"
+            onClick={() => setShowSitePermissions(!showSitePermissions)}
+            className="rounded-full p-1 transition-colors hover:bg-gray-200 dark:hover:bg-slate-700"
+            title="Site permissions"
+          >
+            <Icon icon="mdi:web" className="text-gray-500" />
+          </button>
+        </div>
+
+        <div className="absolute top-full left-2 z-50">
+          <SitePermissionsDropdown
+            currentAddress={address}
+            isVisible={showSitePermissions}
+            onClose={() => setShowSitePermissions(false)}
+          />
+        </div>
+
+        {permissionRequest != null ? (
+          <div className="absolute top-12 left-2 z-40 flex w-96 flex-col gap-8 rounded bg-white p-6 shadow-lg ring-1 ring-slate-500 !ring-opacity-40 focus:outline-none dark:bg-slate-900 dark:ring-white dark:!ring-opacity-40">
+            <span>
+              {permissionRequest.requestingOrigin} requests permission for:{' '}
+              <br />
+              <span className="flex justify-center font-bold capitalize">
+                {permissionRequest.permission}
               </span>
-              <div className="flex justify-end">
-                <div className="flex w-1/2 justify-around">
-                  <Button
-                    onClick={() => {
-                      permissionReqClickHandler(false);
-                    }}
-                    isActionButton
-                  >
-                    Block
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      permissionReqClickHandler(true);
-                    }}
-                    isActionButton
-                  >
-                    Allow
-                  </Button>
-                </div>
+            </span>
+            <div className="flex justify-end">
+              <div className="flex w-1/2 justify-around">
+                <Button
+                  onClick={() => {
+                    permissionReqClickHandler(false);
+                  }}
+                  isActionButton
+                >
+                  Block
+                </Button>
+                <Button
+                  onClick={() => {
+                    permissionReqClickHandler(true);
+                  }}
+                  isActionButton
+                >
+                  Allow
+                </Button>
               </div>
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
         <input
           ref={inputRef}
           type="text"


### PR DESCRIPTION
- Fixes #677

# ✨ Pull Request

### 📓 Referenced Issue

Referenced to the issue #677 
- replaced the globe icon with a clickable icon/button
- added site permissions drop-down, matching the theme of the application


### ℹ️ About the PR

## New Files Created
### `SitePermissionsDropdown` Component
**File**: `desktop-app/src/renderer/components/ToolBar/AddressBar/SitePermissions/index.tsx`

**Features:**
- **Interactive Globe Icon**: Dropdown interface matching application theme
- **8 Permission Types**: Camera, Microphone, Location, Notifications, Clipboard, Fullscreen, MIDI, Pointer Lock
- **3-State Management**: Ask (default) → Allow → Block → Ask (cyclical toggle)

## Modified Files

### `AddressBar` Component Updates
**File**: `desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx`

**Changes:**
- Made globe icon clickable with proper hover effects (`rounded-full`)
- Added `showSitePermissions` state management
- Integrated dropdown positioning and visibility controls
- Added circular hover animation matching other address bar icons

### Backend Permission System Enhancements
**Files Modified:**
- `desktop-app/src/main/web-permissions/PermissionsManager.ts`
- `desktop-app/src/main/web-permissions/index.ts`
- `desktop-app/src/common/constants.ts`
- `desktop-app/src/main/preload-webview.ts`

### 🖼️ Testing Scenarios / Screenshots

- Permission dialog ↔ flyout sync  
- Page refresh notifications and reload  
- Permission reset functionality  
- Session cache clearing  
- Click-outside dropdown behavior  

## Images
<img width="487" height="602" alt="Screenshot From 2025-09-26 18-32-44" src="https://github.com/user-attachments/assets/1d72ed96-1783-468b-8e62-299b2a733e88" />




