### PR TITLE
[Draft] fix: prevent infinite reload loop on SPA client-side navigation

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -31,6 +31,7 @@ export const ADDRESS_BAR_EVENTS = {
   DELETE_COOKIES: 'DELETE_COOKIES',
   DELETE_STORAGE: 'DELETE_STORAGE',
   DELETE_CACHE: 'DELETE_CACHE',
+  NAVIGATE: 'ADDRESS_BAR_NAVIGATE',
 };
 
 const AddressBar = () => {
@@ -64,7 +65,7 @@ const AddressBar = () => {
   }, [address]);
 
   const dispatchAddress = useCallback(
-    (url?: string) => {
+    async (url?: string) => {
       let newAddress = url ?? typedAddress;
       if (newAddress.indexOf('://') === -1) {
         let protocol = 'https://';
@@ -77,6 +78,8 @@ const AddressBar = () => {
         newAddress = protocol + typedAddress;
       }
       if (url && url !== typedAddress) setTypedAddress(url);
+      // Notify Device components that navigation is from address bar (must await before dispatch)
+      await webViewPubSub.publish(ADDRESS_BAR_EVENTS.NAVIGATE);
       dispatch(setAddress(newAddress));
     },
     [dispatch, typedAddress]

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Bookmark/ViewAllBookmarks/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Bookmark/ViewAllBookmarks/index.tsx
@@ -3,6 +3,8 @@ import Button from 'renderer/components/Button';
 import { IBookmarks } from 'renderer/store/features/bookmarks';
 import { setAddress } from 'renderer/store/features/renderer';
 import { useState } from 'react';
+import { webViewPubSub } from 'renderer/lib/pubsub';
+import { ADDRESS_BAR_EVENTS } from 'renderer/components/ToolBar/AddressBar';
 import BookmarkListButton from './BookmarkListButton';
 import BookmarkFlyout from './BookmarkFlyout';
 
@@ -22,7 +24,8 @@ const ViewAllBookmarks = ({ bookmarks, handleBookmarkFlyout }: Props) => {
 
   const areBookmarksPresent = bookmarks.length > 0;
 
-  const handleBookmarkClick = (address: string) => {
+  const handleBookmarkClick = async (address: string) => {
+    await webViewPubSub.publish(ADDRESS_BAR_EVENTS.NAVIGATE);
     dispatch(setAddress(address));
     handleBookmarkFlyout();
   };


### PR DESCRIPTION
### 📓 Referenced Issue
No existing issue - this bug was discovered while testing with a Vue.js application.

### ℹ️ About the PR
**Problem:**
When viewing a Vue.js Single Page Application with client-side routing, navigation triggers `did-navigate` events that caused `loadURL()` to be called repeatedly, creating an infinite reload loop that makes Responsively unusable with SPAs.

**Root Cause:**
The component was treating all navigation events (including SPA client-side routing) the same as user-initiated navigation from the address bar, causing unnecessary page reloads.

**Solution:**
- Added `NAVIGATE` event type to distinguish explicit address bar navigation from SPA routing
- Modified the address bar to publish `NAVIGATE` events only when the user explicitly navigates
- Used `isNavigatingFromAddressBar` ref to track navigation source
- Only call `loadURL()` when navigation originates from the address bar
- Applied the same fix to bookmark navigation to ensure consistent behavior

**Files Changed:**
- `desktop-app/src/renderer/components/Previewer/Device/index.tsx`
- `desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx`
- `desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Bookmark/ViewAllBookmarks/index.tsx`

### 🖼️ Testing Scenarios
**Before:** 
Navigating within a Vue.js SPA (using Vue Router) caused infinite reload loops, making the application unusable.

**After:**
- ✅ Client-side navigation in Vue.js SPA works without reloading
- ✅ Address bar navigation still works correctly
- ✅ Bookmark navigation works correctly
- ✅ No infinite reload loops

**Tested with:**
- Vue.js application with Vue Router for client-side routing