### PR TITLE
fix: cropped app content and previewer layout fixed

### DIFF
--- a/desktop-app/src/renderer/AppContent.tsx
+++ b/desktop-app/src/renderer/AppContent.tsx
@@ -20,7 +20,7 @@ if ((navigator as any).userAgentData.platform === 'Windows') {
 
 const Browser = () => {
   return (
-    <div className="h-screen gap-2 overflow-hidden pt-2">
+    <div className="flex h-screen flex-col overflow-hidden pt-2">
       <ToolBar />
       <Previewer />
     </div>

--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
@@ -46,7 +46,7 @@ const IndividualLayoutToolbar = ({
       >
         <TabList
           className={cx(
-            'custom-scrollbar flex flex-1  justify-center gap-1 overflow-x-auto border-b border-slate-400/60 dark:border-white'
+            'custom-scrollbar flex flex-1 justify-center gap-1 overflow-x-auto border-b border-slate-400/60 dark:border-white'
           )}
         >
           {devices.map((device, idx) => (

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -47,7 +47,7 @@ const Previewer = () => {
   };
 
   return (
-    <div className="h-full">
+    <div className="flex h-full flex-col overflow-hidden">
       {isIndividualLayout && (
         <IndividualLayoutToolbar
           individualDevice={individualDevice}
@@ -56,7 +56,7 @@ const Previewer = () => {
         />
       )}
       <div
-        className={cx('flex h-full', {
+        className={cx('flex overflow-y-auto', {
           'flex-col': dockPosition === DOCK_POSITION.BOTTOM,
           'flex-row': dockPosition === DOCK_POSITION.RIGHT,
           'justify-between': !isIndividualLayout,


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1452 

### ℹ️ About the PR

The problem with the viewport being cropped was fixed using flexbox where appropriate. Also the redundant classes were removed.

### 🖼️ Testing Scenarios / Screenshots
![issue1452fix](https://github.com/user-attachments/assets/e43f3e3a-d2cf-4180-aecc-dd3b9dd839c0)