### PR TITLE
fix(webview): ignore iframe did-navigate-in-page events to prevent un…

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -290,7 +290,11 @@ const Device = ({ isPrimary, device, setIndividualDevice }: Props) => {
     const webview = ref.current as Electron.WebviewTag;
     const handlerRemovers: (() => void)[] = [];
 
-    const didNavigateHandler = (e: Electron.DidNavigateEvent) => {
+    const didNavigateHandler = (
+      e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent
+    ) => {
+      // Only DidNavigateInPageEvent has isMainFrame
+      if ('isMainFrame' in e && e.isMainFrame === false) return;
       // Only update Redux on the primary device and only if this navigation wasn't initiated by AddressBar
       if (isPrimary && !isNavigatingFromAddressBar.current) {
         dispatch(setAddress(e.url));


### PR DESCRIPTION
Hi @manojVivek, I’ve worked on this issue and pushed a fix.

**Issue:**
https://github.com/responsively-org/responsively-app/issues/1388

**Root cause:**
`did-navigate-in-page` events triggered by iframe loads (like Spotify embeds) were being treated as top-level navigations. This updated the address bar to the iframe `src` and caused Responsively to redirect away from the parent page.

**Fix:**
Added a guard so only **main-frame** `did-navigate-in-page` events update the address and history. Iframe navigations are now ignored, preventing unwanted redirects.

**Before (issue):**
![Image](https://github.com/user-attachments/assets/4259b494-9273-450b-94a4-d868aab32340)

![Image](https://github.com/user-attachments/assets/537df876-aa2c-4444-ba23-d246dd721ed2)

**After (fixed):**

![Image](https://github.com/user-attachments/assets/1e011e7e-5e6e-40de-9707-22cbbddfcb83)

![Image](https://github.com/user-attachments/assets/27676c10-8fb4-4cdd-a380-c3a62abcdbe2)

Tested with the reported Spotify embed page and also verified normal SPA navigation, back/forward, and reload flows.
Let me know if any changes are needed.
