### PR TITLE
Disable angular extension as it doesn't work well right now

### DIFF
--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -78,7 +78,7 @@ const installExtensions = async () => {
     'EMBER_INSPECTOR',
     'BACKBONE_DEBUGGER',
     'JQUERY_DEBUGGER',
-    'ANGULAR_DEVTOOLS',
+    // 'ANGULAR_DEVTOOLS',
     'VUEJS_DEVTOOLS',
     'MOBX_DEVTOOLS',
     'APOLLO_DEVELOPER_TOOLS',


### PR DESCRIPTION
Fails with this error:
```
[4650:0215/094201.979086:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
[4650:0215/094201.979190:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
[4650:0215/094203.982905:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
[4650:0215/094203.983042:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
[4650:0215/094205.979927:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
[4650:0215/094205.980052:ERROR:service_worker_task_queue.cc(240)] DidStartWorkerFail kccpmbgkllmjankhdjiilfgejjlcchkg: 2
  ```