### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Responsively-App",
   "productName": "ResponsivelyApp",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "A developer-friendly browser for developing responsive web apps",
   "keywords": [
     "developer-tools",

--- a/desktop-app/release/app/package-lock.json
+++ b/desktop-app/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ResponsivelyApp",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ResponsivelyApp",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/desktop-app/release/app/package.json
+++ b/desktop-app/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ResponsivelyApp",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "A developer-friendly browser for developing responsive web apps",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
### 📓 Referenced Issue

N/A

### ℹ️ About the PR

This PR updates the version number from 1.17.1 to 1.18.0 across the package configuration files in preparation for the next release.

**Changes:**
- Updated `desktop-app/package.json` version to 1.18.0
- Updated `desktop-app/release/app/package.json` version to 1.18.0

### 🖼️ Testing Scenarios / Screenshots

N/A - Version bump only. No testing needed.

https://claude.ai/code/session_01PUeGLqkDUu84Q9jFsCz8me