### PR TITLE
feat: add javascript toggle controls for device previews

### DIFF
--- a/desktop-app/src/renderer/components/DropDown/index.tsx
+++ b/desktop-app/src/renderer/components/DropDown/index.tsx
@@ -20,16 +20,17 @@ interface Props {
   label: JSX.Element | string;
   options: OptionOrSeparator[];
   className?: string | null;
+  showChevron?: boolean;
 }
 
-export function DropDown({label, options, className}: Props) {
+export function DropDown({label, options, className, showChevron = true}: Props) {
   return (
     <div className="relative text-right">
       <Menu as="div" className={`inline-block text-left ${className}`}>
         <Float placement="bottom-end" flip portal>
           <Menu.Button className="inline-flex w-full justify-center gap-1 rounded-md bg-opacity-20 p-2 text-sm font-medium hover:bg-slate-300 hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:hover:bg-slate-700">
             {label}
-            <Icon icon="mdi:chevron-down" />
+            {showChevron ? <Icon icon="mdi:chevron-down" /> : null}
           </Menu.Button>
           <Transition
             as={Fragment}

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.test.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.test.tsx
@@ -1,0 +1,66 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import javascriptReducer from 'renderer/store/features/javascript';
+import Toolbar from './Toolbar';
+
+vi.mock('use-sound', () => ({
+  default: () => [vi.fn()],
+}));
+
+vi.mock('./ColorBlindnessTools', () => ({
+  ColorBlindnessTools: () => null,
+}));
+
+vi.mock('./DesignOverlayControls', () => ({
+  default: () => null,
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      javascript: javascriptReducer,
+    },
+  });
+
+const baseProps = {
+  webview: null,
+  device: {
+    id: '10008',
+    name: 'iPhone XR',
+    width: 414,
+    height: 896,
+    userAgent: 'test-agent',
+    type: 'phone',
+    dpr: 2,
+    isTouchCapable: true,
+    isMobileCapable: true,
+    capabilities: ['touch', 'mobile'],
+  },
+  setScreenshotInProgress: vi.fn(),
+  openDevTools: vi.fn(),
+  toggleRuler: vi.fn(),
+  onRotate: vi.fn(),
+  onIndividualLayoutHandler: vi.fn(),
+  isIndividualLayout: false,
+  isDeviceRotationEnabled: true,
+};
+
+describe('Device Toolbar', () => {
+  it('disables screenshot buttons when javascript is disabled for the preview', () => {
+    render(
+      <Provider store={createStore()}>
+        <Toolbar {...baseProps} isJavaScriptDisabled />
+      </Provider>
+    );
+
+    const disabledButtons = screen.getAllByTitle(
+      'Screenshots are unavailable while JavaScript is disabled for this preview'
+    );
+
+    expect(disabledButtons).toHaveLength(2);
+    disabledButtons.forEach((button) => {
+      expect(button).toBeDisabled();
+    });
+  });
+});

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -1,6 +1,8 @@
 import {Icon} from '@iconify/react';
 import {useState} from 'react';
+import {useDispatch} from 'react-redux';
 import Button from 'renderer/components/Button';
+import {DropDown} from 'renderer/components/DropDown';
 import useSound from 'use-sound';
 import {ScreenshotArgs, ScreenshotResult} from 'main/screenshot';
 import {Device} from 'common/deviceList';
@@ -8,12 +10,14 @@ import WebPage from 'main/screenshot/webpage';
 
 import screenshotSfx from 'renderer/assets/sfx/screenshot.mp3';
 import {updateWebViewHeightAndScale} from 'common/webViewUtils';
+import {setDeviceJavaScriptDisabled} from 'renderer/store/features/javascript';
 import {ColorBlindnessTools} from './ColorBlindnessTools';
 import DesignOverlayControls from './DesignOverlayControls';
 
 interface Props {
   webview: Electron.WebviewTag | null;
   device: Device;
+  isJavaScriptDisabled: boolean;
   setScreenshotInProgress: (value: boolean) => void;
   openDevTools: () => void;
   toggleRuler: () => void;
@@ -26,6 +30,7 @@ interface Props {
 const Toolbar = ({
   webview,
   device,
+  isJavaScriptDisabled,
   setScreenshotInProgress,
   openDevTools,
   toggleRuler,
@@ -34,12 +39,15 @@ const Toolbar = ({
   isIndividualLayout,
   isDeviceRotationEnabled,
 }: Props) => {
+  const dispatch = useDispatch();
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, {volume: 0.5});
   const [screenshotLoading, setScreenshotLoading] = useState<boolean>(false);
   const [fullScreenshotLoading, setFullScreenshotLoading] = useState<boolean>(false);
   const [rotated, setRotated] = useState<boolean>(false);
   const [isDesignOverlayModalOpen, setIsDesignOverlayModalOpen] = useState<boolean>(false);
+  const screenshotDisabledTitle =
+    'Screenshots are unavailable while JavaScript is disabled for this preview';
 
   const refreshView = () => {
     if (webview) {
@@ -68,7 +76,7 @@ const Toolbar = ({
   };
 
   const quickScreenshot = async () => {
-    if (webview === null) {
+    if (webview === null || isJavaScriptDisabled) {
       return;
     }
     setScreenshotLoading(true);
@@ -86,7 +94,7 @@ const Toolbar = ({
   };
 
   const fullScreenshot = async () => {
-    if (webview === null) {
+    if (webview === null || isJavaScriptDisabled) {
       return;
     }
     setFullScreenshotLoading(true);
@@ -139,13 +147,27 @@ const Toolbar = ({
     }
   };
 
+  const toggleJavaScript = () => {
+    dispatch(
+      setDeviceJavaScriptDisabled({
+        deviceId: device.id,
+        disabled: !isJavaScriptDisabled,
+      })
+    );
+  };
+
   return (
     <div className="flex items-center justify-between gap-1">
       <div className="my-1 inline-flex max-w-[78%] items-center gap-1 overflow-x-auto">
         <Button onClick={refreshView} title="Refresh This View">
           <Icon icon="ic:round-refresh" />
         </Button>
-        <Button onClick={quickScreenshot} isLoading={screenshotLoading} title="Quick Screenshot">
+        <Button
+          onClick={quickScreenshot}
+          isLoading={screenshotLoading}
+          disabled={isJavaScriptDisabled}
+          title={isJavaScriptDisabled ? screenshotDisabledTitle : 'Quick Screenshot'}
+        >
           <div className="relative h-4 w-4">
             <Icon icon="ic:outline-photo-camera" className="absolute left-0 top-0" />
             <Icon
@@ -158,7 +180,8 @@ const Toolbar = ({
         <Button
           onClick={fullScreenshot}
           isLoading={fullScreenshotLoading}
-          title="Full Page Screenshot"
+          disabled={isJavaScriptDisabled}
+          title={isJavaScriptDisabled ? screenshotDisabledTitle : 'Full Page Screenshot'}
         >
           <Icon icon="ic:outline-photo-camera" />
         </Button>
@@ -194,12 +217,29 @@ const Toolbar = ({
         </Button>
         <ColorBlindnessTools webview={webview} />
       </div>
-      <Button
-        onClick={() => onIndividualLayoutHandler(device)}
-        title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}
-      >
-        <Icon icon={isIndividualLayout ? 'ic:twotone-zoom-in-map' : 'ic:twotone-zoom-out-map'} />
-      </Button>
+      <div className="flex items-center gap-1">
+        <DropDown
+          showChevron={false}
+          label={
+            <>
+              <span className="sr-only">More options</span>
+              <Icon icon="carbon:overflow-menu-vertical" />
+            </>
+          }
+          options={[
+            {
+              label: isJavaScriptDisabled ? 'Enable JavaScript' : 'Disable JavaScript',
+              onClick: toggleJavaScript,
+            },
+          ]}
+        />
+        <Button
+          onClick={() => onIndividualLayoutHandler(device)}
+          title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}
+        >
+          <Icon icon={isIndividualLayout ? 'ic:twotone-zoom-in-map' : 'ic:twotone-zoom-out-map'} />
+        </Button>
+      </div>
       <DesignOverlayControls
         device={device}
         isOpen={isDesignOverlayModalOpen}

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -60,6 +60,7 @@ import {appendHistory} from './utils';
 interface Props {
   device: IDevice;
   isPrimary: boolean;
+  isJavaScriptDisabled: boolean;
   setIndividualDevice: (device: IDevice) => void;
 }
 
@@ -68,7 +69,7 @@ interface ErrorState {
   description: string;
 }
 
-const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
+const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: Props) => {
   const [singleRotated, setSingleRotated] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ErrorState | null>(null);
@@ -558,6 +559,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       <Toolbar
         webview={ref.current}
         device={device}
+        isJavaScriptDisabled={isJavaScriptDisabled}
         setScreenshotInProgress={setScreenshotInProgress}
         openDevTools={openDevTools}
         toggleRuler={toggleRuler}
@@ -611,6 +613,8 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
               allowpopups={isPrimary ? true : undefined}
               /* eslint-disable-next-line react/no-unknown-property */
               useragent={device.userAgent}
+              /* eslint-disable-next-line react/no-unknown-property */
+              webpreferences={isJavaScriptDisabled ? 'javascript=no' : undefined}
             />
           </div>
 

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -6,6 +6,7 @@ import {selectDockPosition, selectIsDevtoolsOpen} from 'renderer/store/features/
 import {getDevicesMap, Device as IDevice} from 'common/deviceList';
 import {useState} from 'react';
 import {selectLayout} from 'renderer/store/features/renderer';
+import {selectJavaScriptDisabledByDeviceId} from 'renderer/store/features/javascript';
 import Masonry from 'react-masonry-component';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
@@ -32,6 +33,7 @@ const Previewer = () => {
   const dockPosition = useSelector(selectDockPosition);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
   const isMasonryLayout = layout === PREVIEW_LAYOUTS.MASONRY; // New state for Masonry layout
@@ -42,6 +44,8 @@ const Previewer = () => {
     fitWidth: true,
     transitionDuration: 0,
   };
+  const getDeviceRenderKey = (deviceId: string) =>
+    `${deviceId}-${disabledJavaScriptByDeviceId[deviceId] ? 'js-off' : 'js-on'}`;
 
   return (
     <div className="h-full">
@@ -65,10 +69,11 @@ const Previewer = () => {
             {isMasonryLayout ? (
               <TypedMasonry options={masonryOptions} className="w-full gap-4 p-2">
                 {devices.map((device) => (
-                  <div key={device.id} className="device-item p-4">
+                  <div key={getDeviceRenderKey(device.id)} className="device-item p-4">
                     <Device
                       device={device}
                       isPrimary={device.id === devices[0].id}
+                      isJavaScriptDisabled={Boolean(disabledJavaScriptByDeviceId[device.id])}
                       setIndividualDevice={setIndividualDevice}
                     />
                   </div>
@@ -83,17 +88,21 @@ const Previewer = () => {
               >
                 {isIndividualLayout ? (
                   <Device
-                    key={individualDevice.id}
+                    key={getDeviceRenderKey(individualDevice.id)}
                     device={individualDevice}
                     isPrimary
+                    isJavaScriptDisabled={Boolean(
+                      disabledJavaScriptByDeviceId[individualDevice.id]
+                    )}
                     setIndividualDevice={setIndividualDevice}
                   />
                 ) : (
                   devices.map((device, idx) => (
                     <Device
-                      key={device.id}
+                      key={getDeviceRenderKey(device.id)}
                       device={device}
                       isPrimary={idx === 0}
+                      isJavaScriptDisabled={Boolean(disabledJavaScriptByDeviceId[device.id])}
                       setIndividualDevice={setIndividualDevice}
                     />
                   ))

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx
@@ -1,0 +1,41 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import javascriptReducer from 'renderer/store/features/javascript';
+import JavaScriptControls from './index';
+
+const activeSuite = {
+  id: 'default',
+  name: 'Default',
+  devices: ['10008', '10013'],
+};
+
+vi.mock('renderer/store/features/device-manager', () => ({
+  selectActiveSuite: () => activeSuite,
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      javascript: javascriptReducer,
+    },
+  });
+
+describe('JavaScriptControls', () => {
+  it('disables javascript for all active previews from the global menu', () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <JavaScriptControls />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(store.getState().javascript.disabledByDeviceId).toEqual({
+      '10008': true,
+      '10013': true,
+    });
+  });
+});

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.tsx
@@ -1,0 +1,37 @@
+import {useDispatch, useSelector} from 'react-redux';
+import Toggle from 'renderer/components/Toggle';
+import {selectActiveSuite} from 'renderer/store/features/device-manager';
+import {
+  selectJavaScriptDisabledByDeviceId,
+  setDevicesJavaScriptDisabled,
+} from 'renderer/store/features/javascript';
+
+const JavaScriptControls = () => {
+  const dispatch = useDispatch();
+  const activeSuite = useSelector(selectActiveSuite);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
+  const isEnabledForAllDevices = activeSuite.devices.every(
+    (deviceId) => !disabledJavaScriptByDeviceId[deviceId]
+  );
+
+  return (
+    <div className="flex flex-row items-center justify-start px-4">
+      <span className="w-1/2">JavaScript (All Previews)</span>
+      <div className="flex items-center gap-2 border-l px-4 dark:border-slate-400">
+        <Toggle
+          isOn={isEnabledForAllDevices}
+          onChange={(value) => {
+            dispatch(
+              setDevicesJavaScriptDisabled({
+                deviceIds: activeSuite.devices,
+                disabled: !value.target.checked,
+              })
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default JavaScriptControls;

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
@@ -5,6 +5,7 @@ import UITheme from './UITheme';
 import Zoom from './Zoom';
 import AllowInSecureSSL from './AllowInSecureSSL';
 import ClearHistory from './ClearHistory';
+import JavaScriptControls from './JavaScriptControls';
 import PreviewLayout from './PreviewLayout';
 import Bookmark from './Bookmark';
 import {Settings} from './Settings';
@@ -20,6 +21,7 @@ const MenuFlyout = ({closeFlyout}: Props) => {
       <UITheme />
       <Devtools />
       <AllowInSecureSSL />
+      <JavaScriptControls />
       <ClearHistory />
       <Divider />
 

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -6,10 +6,10 @@ import {
   setIsCapturingScreenshot,
   setIsInspecting,
   setRotate,
-  setNotifications,
 } from 'renderer/store/features/renderer';
 import {Icon} from '@iconify/react';
 import {ScreenshotAllArgs} from 'main/screenshot';
+import {selectJavaScriptDisabledByDeviceId} from 'renderer/store/features/javascript';
 import {selectActiveSuite} from 'renderer/store/features/device-manager';
 import WebPage from 'main/screenshot/webpage';
 import {getDevicesMap} from 'common/deviceList';
@@ -35,14 +35,21 @@ const ToolBar = () => {
   const isInspecting = useSelector(selectIsInspecting);
   const isCapturingScreenshot = useSelector(selectIsCapturingScreenshot);
   const activeSuite = useSelector(selectActiveSuite);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
   const dispatch = useDispatch();
+  const isAnyJavaScriptDisabled = activeSuite.devices.some(
+    (deviceId) => disabledJavaScriptByDeviceId[deviceId]
+  );
+  const screenshotAllTitle = isAnyJavaScriptDisabled
+    ? 'Screenshot All WebViews is unavailable while JavaScript is disabled for one or more previews'
+    : 'Screenshot All WebViews';
 
   function handleInspectShortcut() {
     dispatch(setIsInspecting(!isInspecting));
   }
 
   const screenshotCaptureHandler = async () => {
-    if (isCapturingScreenshot) {
+    if (isCapturingScreenshot || isAnyJavaScriptDisabled) {
       return;
     }
 
@@ -114,7 +121,8 @@ const ToolBar = () => {
       <Button
         onClick={screenshotCaptureHandler}
         isActive={isCapturingScreenshot}
-        title="Screenshot All WebViews"
+        disabled={isAnyJavaScriptDisabled}
+        title={screenshotAllTitle}
       >
         <Icon icon="lucide:camera" />
       </Button>

--- a/desktop-app/src/renderer/store/features/javascript/index.test.ts
+++ b/desktop-app/src/renderer/store/features/javascript/index.test.ts
@@ -1,0 +1,54 @@
+import javascriptReducer, {
+  setDeviceJavaScriptDisabled,
+  setDevicesJavaScriptDisabled,
+  type JavaScriptState,
+} from './index';
+
+describe('javascriptSlice', () => {
+  it('disables and re-enables javascript for a single device', () => {
+    const initialState: JavaScriptState = {
+      disabledByDeviceId: {},
+    };
+
+    const disabledState = javascriptReducer(
+      initialState,
+      setDeviceJavaScriptDisabled({deviceId: '10008', disabled: true})
+    );
+
+    expect(disabledState.disabledByDeviceId).toEqual({
+      '10008': true,
+    });
+
+    const enabledState = javascriptReducer(
+      disabledState,
+      setDeviceJavaScriptDisabled({deviceId: '10008', disabled: false})
+    );
+
+    expect(enabledState.disabledByDeviceId).toEqual({});
+  });
+
+  it('toggles javascript for multiple devices at once', () => {
+    const initialState: JavaScriptState = {
+      disabledByDeviceId: {
+        '10008': true,
+      },
+    };
+
+    const disabledState = javascriptReducer(
+      initialState,
+      setDevicesJavaScriptDisabled({deviceIds: ['10008', '10013'], disabled: true})
+    );
+
+    expect(disabledState.disabledByDeviceId).toEqual({
+      '10008': true,
+      '10013': true,
+    });
+
+    const enabledState = javascriptReducer(
+      disabledState,
+      setDevicesJavaScriptDisabled({deviceIds: ['10008', '10013'], disabled: false})
+    );
+
+    expect(enabledState.disabledByDeviceId).toEqual({});
+  });
+});

--- a/desktop-app/src/renderer/store/features/javascript/index.ts
+++ b/desktop-app/src/renderer/store/features/javascript/index.ts
@@ -1,0 +1,52 @@
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import type {RootState} from '../..';
+
+export interface JavaScriptState {
+  disabledByDeviceId: Record<string, boolean>;
+}
+
+const initialState: JavaScriptState = {
+  disabledByDeviceId: {},
+};
+
+export const javascriptSlice = createSlice({
+  name: 'javascript',
+  initialState,
+  reducers: {
+    setDeviceJavaScriptDisabled: (
+      state,
+      action: PayloadAction<{deviceId: string; disabled: boolean}>
+    ) => {
+      const {deviceId, disabled} = action.payload;
+
+      if (disabled) {
+        state.disabledByDeviceId[deviceId] = true;
+        return;
+      }
+
+      delete state.disabledByDeviceId[deviceId];
+    },
+    setDevicesJavaScriptDisabled: (
+      state,
+      action: PayloadAction<{deviceIds: string[]; disabled: boolean}>
+    ) => {
+      const {deviceIds, disabled} = action.payload;
+
+      deviceIds.forEach((deviceId) => {
+        if (disabled) {
+          state.disabledByDeviceId[deviceId] = true;
+          return;
+        }
+
+        delete state.disabledByDeviceId[deviceId];
+      });
+    },
+  },
+});
+
+export const {setDeviceJavaScriptDisabled, setDevicesJavaScriptDisabled} = javascriptSlice.actions;
+
+export const selectJavaScriptDisabledByDeviceId = (state: RootState) =>
+  state.javascript.disabledByDeviceId;
+
+export default javascriptSlice.reducer;

--- a/desktop-app/src/renderer/store/index.ts
+++ b/desktop-app/src/renderer/store/index.ts
@@ -2,6 +2,7 @@ import {configureStore} from '@reduxjs/toolkit';
 
 import deviceManagerReducer from './features/device-manager';
 import devtoolsReducer from './features/devtools';
+import javascriptReducer from './features/javascript';
 import rendererReducer from './features/renderer';
 import rulersReducer from './features/ruler';
 import uiReducer from './features/ui';
@@ -13,6 +14,7 @@ export const store = configureStore({
     renderer: rendererReducer,
     ui: uiReducer,
     deviceManager: deviceManagerReducer,
+    javascript: javascriptReducer,
     devtools: devtoolsReducer,
     bookmarks: bookmarkReducer,
     rulers: rulersReducer,


### PR DESCRIPTION
## Summary
This adds narrow JavaScript toggle controls for Responsively previews.

## Root cause
Issue #490 already identified that `webpreferences` must be set when a `webview` is created, so changing the attribute on an already-mounted preview does not actually disable JavaScript. The same issue thread also documented that screenshot capture breaks while JavaScript is disabled, which left the existing screenshot actions unsafe in that mode.

## Changes
- add shared renderer state for which preview devices currently have JavaScript disabled
- add a per-preview JavaScript toggle in the device toolbar overflow menu and an all-previews toggle in the main overflow menu
- re-mount preview devices when their JavaScript mode changes so the `webview` is recreated with `webpreferences="javascript=no"`
- disable per-preview and global screenshot actions while JavaScript is disabled, with explicit tooltip copy explaining why
- add targeted tests for the new renderer state, the global toggle, and the screenshot-disabled toolbar behavior

## Verification
- `npx vitest run src/renderer/store/features/javascript/index.test.ts src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx src/renderer/components/Previewer/Device/Toolbar.test.tsx`
- `npx tsc --noEmit`
- `npx eslint src/renderer/store/features/javascript/index.ts src/renderer/store/features/javascript/index.test.ts src/renderer/store/index.ts src/renderer/components/Previewer/index.tsx src/renderer/components/Previewer/Device/index.tsx src/renderer/components/Previewer/Device/Toolbar.tsx src/renderer/components/Previewer/Device/Toolbar.test.tsx src/renderer/components/ToolBar/index.tsx src/renderer/components/ToolBar/Menu/Flyout/index.tsx src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.tsx src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx src/renderer/components/DropDown/index.tsx` (no errors; a few legacy warnings remain in touched files)
- `npm run build:renderer` currently fails in this local Windows environment before bundling because the existing `delete-source-maps`/`rimraf` wildcard path is rejected
- `npx cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.ts` currently falls back to the existing DLL/postinstall path and fails locally because plain `yarn` is not available on PATH

Closes #490
