### PR TITLE
feat: add javascript toggle controls for device previews

### DIFF
--- a/desktop-app/e2e/tests/device-toolbar.spec.ts
+++ b/desktop-app/e2e/tests/device-toolbar.spec.ts
@@ -1,6 +1,8 @@
 import {ElectronApplication, Page} from '@playwright/test';
 import {test, expect} from '../fixtures/electron-app';
 
+const WEBVIEW_EXECUTION_FAILED = '__WEBVIEW_EXECUTION_FAILED__';
+
 const execInWebview = async (
   electronApp: ElectronApplication,
   wcId: number,
@@ -10,9 +12,13 @@ const execInWebview = async (
     async ({webContents}, {id, js}: {id: number; js: string}) => {
       const wc = webContents.fromId(id);
       if (!wc) {
-        throw new Error(`No webContents with id ${id}`);
+        return WEBVIEW_EXECUTION_FAILED;
       }
-      return wc.executeJavaScript(js);
+      try {
+        return await wc.executeJavaScript(js);
+      } catch (_error) {
+        return WEBVIEW_EXECUTION_FAILED;
+      }
     },
     {id: wcId, js: script}
   );
@@ -198,7 +204,7 @@ test.describe('Device Toolbar', () => {
           ),
         {timeout: 10_000}
       )
-      .toBe('undefined');
+      .toBe(WEBVIEW_EXECUTION_FAILED);
     await expect
       .poll(
         () =>

--- a/desktop-app/e2e/tests/device-toolbar.spec.ts
+++ b/desktop-app/e2e/tests/device-toolbar.spec.ts
@@ -155,16 +155,23 @@ test.describe('Device Toolbar', () => {
       )
       .toBe('number');
 
-    const quickScreenshotBtn = app.page.locator('button[title="Quick Screenshot"]').first();
-    const fullPageScreenshotBtn = app.page.locator('button[title="Full Page Screenshot"]').first();
+    const firstToolbar = app.page
+      .locator('button[title="Refresh This View"]')
+      .first()
+      .locator('xpath=ancestor::div[contains(@class, "flex items-center justify-between gap-1")]');
+    const toolbarButtons = firstToolbar.locator(
+      'xpath=.//div[contains(@class, "my-1 inline-flex")]//button'
+    );
+    const quickScreenshotBtn = toolbarButtons.nth(1);
+    const fullPageScreenshotBtn = toolbarButtons.nth(2);
     const disabledTitle =
       'Screenshots are unavailable while JavaScript is disabled for this preview';
 
     await expect(quickScreenshotBtn).toBeEnabled();
     await expect(fullPageScreenshotBtn).toBeEnabled();
 
-    await app.page.getByRole('button', {name: 'More options'}).first().click();
-    await app.page.getByRole('button', {name: 'Disable JavaScript'}).click();
+    await firstToolbar.locator('button:has(span.sr-only)').first().click();
+    await app.page.locator('button:has-text("Disable JavaScript")').click();
 
     await expect(quickScreenshotBtn).toBeDisabled();
     await expect(fullPageScreenshotBtn).toBeDisabled();
@@ -204,18 +211,11 @@ test.describe('Device Toolbar', () => {
       )
       .toBe('number');
 
-    await app.page.getByRole('button', {name: 'More options'}).first().click();
-    await app.page.getByRole('button', {name: 'Enable JavaScript'}).click();
+    await firstToolbar.locator('button:has(span.sr-only)').first().click();
+    await app.page.locator('button:has-text("Enable JavaScript")').click();
 
-    const reenabledQuickScreenshotBtn = app.page
-      .locator('button[title="Quick Screenshot"]')
-      .first();
-    const reenabledFullPageScreenshotBtn = app.page
-      .locator('button[title="Full Page Screenshot"]')
-      .first();
-
-    await expect(reenabledQuickScreenshotBtn).toBeEnabled();
-    await expect(reenabledFullPageScreenshotBtn).toBeEnabled();
+    await expect(quickScreenshotBtn).toBeEnabled();
+    await expect(fullPageScreenshotBtn).toBeEnabled();
 
     await expect
       .poll(() => getNthWebviewId(app.page, 0), {timeout: 10_000})

--- a/desktop-app/e2e/tests/device-toolbar.spec.ts
+++ b/desktop-app/e2e/tests/device-toolbar.spec.ts
@@ -1,4 +1,29 @@
+import {ElectronApplication, Page} from '@playwright/test';
 import {test, expect} from '../fixtures/electron-app';
+
+const execInWebview = async (
+  electronApp: ElectronApplication,
+  wcId: number,
+  script: string
+): Promise<unknown> => {
+  return electronApp.evaluate(
+    async ({webContents}, {id, js}: {id: number; js: string}) => {
+      const wc = webContents.fromId(id);
+      if (!wc) {
+        throw new Error(`No webContents with id ${id}`);
+      }
+      return wc.executeJavaScript(js);
+    },
+    {id: wcId, js: script}
+  );
+};
+
+const getNthWebviewId = async (page: Page, index: number): Promise<number | null> => {
+  return page.evaluate((nth) => {
+    const webview = document.querySelectorAll('webview')[nth] as Electron.WebviewTag | undefined;
+    return webview?.getWebContentsId?.() ?? null;
+  }, index);
+};
 
 test.describe('Device Toolbar', () => {
   test('each device shows its name and dimensions in the header', async ({app}) => {
@@ -88,5 +113,130 @@ test.describe('Device Toolbar', () => {
     // Click again to disable for cleanup
     await rulerBtn.click();
     await app.page.waitForTimeout(300);
+  });
+
+  test('per-device javascript toggle remounts only the targeted preview and blocks screenshots', async ({
+    app,
+    testServerUrl,
+  }) => {
+    await app.dismissModals();
+    await app.navigateTo(`${testServerUrl}/test-page.html`, {timeout: 5000});
+
+    await expect(app.firstWebview).toHaveAttribute('src', /test-page\.html/, {
+      timeout: 15_000,
+    });
+
+    const initialFirstWebviewId = await getNthWebviewId(app.page, 0);
+    const initialSecondWebviewId = await getNthWebviewId(app.page, 1);
+
+    expect(initialFirstWebviewId).not.toBeNull();
+    expect(initialSecondWebviewId).not.toBeNull();
+
+    await expect
+      .poll(
+        () =>
+          execInWebview(
+            app.electronApp,
+            initialFirstWebviewId as number,
+            'typeof window.testClickCount'
+          ),
+        {timeout: 10_000}
+      )
+      .toBe('number');
+    await expect
+      .poll(
+        () =>
+          execInWebview(
+            app.electronApp,
+            initialSecondWebviewId as number,
+            'typeof window.testClickCount'
+          ),
+        {timeout: 10_000}
+      )
+      .toBe('number');
+
+    const quickScreenshotBtn = app.page.locator('button[title="Quick Screenshot"]').first();
+    const fullPageScreenshotBtn = app.page.locator('button[title="Full Page Screenshot"]').first();
+    const disabledTitle =
+      'Screenshots are unavailable while JavaScript is disabled for this preview';
+
+    await expect(quickScreenshotBtn).toBeEnabled();
+    await expect(fullPageScreenshotBtn).toBeEnabled();
+
+    await app.page.getByRole('button', {name: 'More options'}).first().click();
+    await app.page.getByRole('button', {name: 'Disable JavaScript'}).click();
+
+    await expect(quickScreenshotBtn).toBeDisabled();
+    await expect(fullPageScreenshotBtn).toBeDisabled();
+    await expect(quickScreenshotBtn).toHaveAttribute('title', disabledTitle);
+    await expect(fullPageScreenshotBtn).toHaveAttribute('title', disabledTitle);
+
+    await expect
+      .poll(() => getNthWebviewId(app.page, 0), {timeout: 10_000})
+      .not.toBe(initialFirstWebviewId);
+
+    const disabledFirstWebviewId = await getNthWebviewId(app.page, 0);
+    const disabledSecondWebviewId = await getNthWebviewId(app.page, 1);
+
+    expect(disabledFirstWebviewId).not.toBeNull();
+    expect(disabledSecondWebviewId).toBe(initialSecondWebviewId);
+
+    await expect
+      .poll(
+        () =>
+          execInWebview(
+            app.electronApp,
+            disabledFirstWebviewId as number,
+            'typeof window.testClickCount'
+          ),
+        {timeout: 10_000}
+      )
+      .toBe('undefined');
+    await expect
+      .poll(
+        () =>
+          execInWebview(
+            app.electronApp,
+            disabledSecondWebviewId as number,
+            'typeof window.testClickCount'
+          ),
+        {timeout: 10_000}
+      )
+      .toBe('number');
+
+    await app.page.getByRole('button', {name: 'More options'}).first().click();
+    await app.page.getByRole('button', {name: 'Enable JavaScript'}).click();
+
+    const reenabledQuickScreenshotBtn = app.page
+      .locator('button[title="Quick Screenshot"]')
+      .first();
+    const reenabledFullPageScreenshotBtn = app.page
+      .locator('button[title="Full Page Screenshot"]')
+      .first();
+
+    await expect(reenabledQuickScreenshotBtn).toBeEnabled();
+    await expect(reenabledFullPageScreenshotBtn).toBeEnabled();
+
+    await expect
+      .poll(() => getNthWebviewId(app.page, 0), {timeout: 10_000})
+      .not.toBe(disabledFirstWebviewId);
+
+    const reenabledFirstWebviewId = await getNthWebviewId(app.page, 0);
+    const reenabledSecondWebviewId = await getNthWebviewId(app.page, 1);
+
+    expect(reenabledFirstWebviewId).not.toBeNull();
+    expect(reenabledSecondWebviewId).toBe(initialSecondWebviewId);
+
+    await expect
+      .poll(
+        () =>
+          execInWebview(
+            app.electronApp,
+            reenabledFirstWebviewId as number,
+            'typeof window.testClickCount'
+          ),
+        {timeout: 10_000}
+      )
+      .toBe('number');
   });
 });

--- a/desktop-app/e2e/tests/menu-flyout.spec.ts
+++ b/desktop-app/e2e/tests/menu-flyout.spec.ts
@@ -173,7 +173,7 @@ test.describe('Menu Flyout', () => {
         .toBe('number');
     }
 
-    const screenshotAllBtn = app.page.locator('button[title="Screenshot All WebViews"]');
+    const screenshotAllBtn = app.page.locator('button[title^="Screenshot All WebViews"]');
     await expect(screenshotAllBtn).toBeEnabled();
 
     await app.openMenuFlyout();

--- a/desktop-app/e2e/tests/menu-flyout.spec.ts
+++ b/desktop-app/e2e/tests/menu-flyout.spec.ts
@@ -1,6 +1,8 @@
 import {ElectronApplication} from '@playwright/test';
 import {test, expect} from '../fixtures/electron-app';
 
+const WEBVIEW_EXECUTION_FAILED = '__WEBVIEW_EXECUTION_FAILED__';
+
 const getWebviewIds = async (electronApp: ElectronApplication): Promise<number[]> => {
   return electronApp.evaluate(({webContents}) => {
     return webContents
@@ -19,9 +21,13 @@ const execInWebview = async (
     async ({webContents}, {id, js}: {id: number; js: string}) => {
       const wc = webContents.fromId(id);
       if (!wc) {
-        throw new Error(`No webContents with id ${id}`);
+        return WEBVIEW_EXECUTION_FAILED;
       }
-      return wc.executeJavaScript(js);
+      try {
+        return await wc.executeJavaScript(js);
+      } catch (_error) {
+        return WEBVIEW_EXECUTION_FAILED;
+      }
     },
     {id: wcId, js: script}
   );
@@ -201,7 +207,7 @@ test.describe('Menu Flyout', () => {
         .poll(() => execInWebview(app.electronApp, id, 'typeof window.testClickCount'), {
           timeout: 10_000,
         })
-        .toBe('undefined');
+        .toBe(WEBVIEW_EXECUTION_FAILED);
     }
 
     await app.closeMenuFlyout();

--- a/desktop-app/e2e/tests/menu-flyout.spec.ts
+++ b/desktop-app/e2e/tests/menu-flyout.spec.ts
@@ -1,4 +1,31 @@
+import {ElectronApplication} from '@playwright/test';
 import {test, expect} from '../fixtures/electron-app';
+
+const getWebviewIds = async (electronApp: ElectronApplication): Promise<number[]> => {
+  return electronApp.evaluate(({webContents}) => {
+    return webContents
+      .getAllWebContents()
+      .filter((wc: Electron.WebContents & {getType?: () => string}) => wc.getType?.() === 'webview')
+      .map((wc: Electron.WebContents) => wc.id);
+  });
+};
+
+const execInWebview = async (
+  electronApp: ElectronApplication,
+  wcId: number,
+  script: string
+): Promise<unknown> => {
+  return electronApp.evaluate(
+    async ({webContents}, {id, js}: {id: number; js: string}) => {
+      const wc = webContents.fromId(id);
+      if (!wc) {
+        throw new Error(`No webContents with id ${id}`);
+      }
+      return wc.executeJavaScript(js);
+    },
+    {id: wcId, js: script}
+  );
+};
 
 test.describe('Menu Flyout', () => {
   test('clicking the overflow menu button opens the flyout', async ({app}) => {
@@ -120,6 +147,87 @@ test.describe('Menu Flyout', () => {
     await app.openMenuFlyout();
 
     await expect(app.page.getByText('Settings')).toBeVisible();
+
+    await app.closeMenuFlyout();
+  });
+
+  test('javascript all previews toggle disables every preview and blocks screenshot all', async ({
+    app,
+    testServerUrl,
+  }) => {
+    await app.dismissModals();
+    await app.navigateTo(`${testServerUrl}/test-page.html`, {timeout: 5000});
+
+    await expect(app.firstWebview).toHaveAttribute('src', /test-page\.html/, {
+      timeout: 15_000,
+    });
+
+    const initialIds = await getWebviewIds(app.electronApp);
+    expect(initialIds.length).toBeGreaterThanOrEqual(1);
+
+    for (const id of initialIds) {
+      await expect
+        .poll(() => execInWebview(app.electronApp, id, 'typeof window.testClickCount'), {
+          timeout: 10_000,
+        })
+        .toBe('number');
+    }
+
+    const screenshotAllBtn = app.page.locator('button[title="Screenshot All WebViews"]');
+    await expect(screenshotAllBtn).toBeEnabled();
+
+    await app.openMenuFlyout();
+    const jsRow = app.page.getByText('JavaScript (All Previews)').locator('xpath=..');
+    const jsToggle = jsRow.locator('input[type="checkbox"]');
+
+    await expect(jsToggle).toBeChecked();
+    await jsToggle.uncheck({force: true});
+
+    await expect(screenshotAllBtn).toBeDisabled();
+    await expect(screenshotAllBtn).toHaveAttribute(
+      'title',
+      'Screenshot All WebViews is unavailable while JavaScript is disabled for one or more previews'
+    );
+
+    await expect
+      .poll(async () => JSON.stringify(await getWebviewIds(app.electronApp)), {timeout: 10_000})
+      .not.toBe(JSON.stringify(initialIds));
+
+    const disabledIds = await getWebviewIds(app.electronApp);
+    expect(disabledIds.length).toBe(initialIds.length);
+
+    for (const id of disabledIds) {
+      await expect
+        .poll(() => execInWebview(app.electronApp, id, 'typeof window.testClickCount'), {
+          timeout: 10_000,
+        })
+        .toBe('undefined');
+    }
+
+    await app.closeMenuFlyout();
+    await app.openMenuFlyout();
+    const reenabledToggle = app.page
+      .getByText('JavaScript (All Previews)')
+      .locator('xpath=..')
+      .locator('input[type="checkbox"]');
+
+    await reenabledToggle.check({force: true});
+
+    await expect(screenshotAllBtn).toBeEnabled();
+    await expect(screenshotAllBtn).toHaveAttribute('title', 'Screenshot All WebViews');
+
+    await expect
+      .poll(async () => JSON.stringify(await getWebviewIds(app.electronApp)), {timeout: 10_000})
+      .not.toBe(JSON.stringify(disabledIds));
+
+    const reenabledIds = await getWebviewIds(app.electronApp);
+    for (const id of reenabledIds) {
+      await expect
+        .poll(() => execInWebview(app.electronApp, id, 'typeof window.testClickCount'), {
+          timeout: 10_000,
+        })
+        .toBe('number');
+    }
 
     await app.closeMenuFlyout();
   });

--- a/desktop-app/src/renderer/components/DropDown/index.tsx
+++ b/desktop-app/src/renderer/components/DropDown/index.tsx
@@ -20,16 +20,17 @@ interface Props {
   label: JSX.Element | string;
   options: OptionOrSeparator[];
   className?: string | null;
+  showChevron?: boolean;
 }
 
-export function DropDown({label, options, className}: Props) {
+export function DropDown({label, options, className, showChevron = true}: Props) {
   return (
     <div className="relative text-right">
       <Menu as="div" className={`inline-block text-left ${className}`}>
         <Float placement="bottom-end" flip portal>
           <Menu.Button className="inline-flex w-full justify-center gap-1 rounded-md bg-opacity-20 p-2 text-sm font-medium hover:bg-slate-300 hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:hover:bg-slate-700">
             {label}
-            <Icon icon="mdi:chevron-down" />
+            {showChevron ? <Icon icon="mdi:chevron-down" /> : null}
           </Menu.Button>
           <Transition
             as={Fragment}

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.test.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.test.tsx
@@ -1,0 +1,66 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import javascriptReducer from 'renderer/store/features/javascript';
+import Toolbar from './Toolbar';
+
+vi.mock('use-sound', () => ({
+  default: () => [vi.fn()],
+}));
+
+vi.mock('./ColorBlindnessTools', () => ({
+  ColorBlindnessTools: () => null,
+}));
+
+vi.mock('./DesignOverlayControls', () => ({
+  default: () => null,
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      javascript: javascriptReducer,
+    },
+  });
+
+const baseProps = {
+  webview: null,
+  device: {
+    id: '10008',
+    name: 'iPhone XR',
+    width: 414,
+    height: 896,
+    userAgent: 'test-agent',
+    type: 'phone',
+    dpr: 2,
+    isTouchCapable: true,
+    isMobileCapable: true,
+    capabilities: ['touch', 'mobile'],
+  },
+  setScreenshotInProgress: vi.fn(),
+  openDevTools: vi.fn(),
+  toggleRuler: vi.fn(),
+  onRotate: vi.fn(),
+  onIndividualLayoutHandler: vi.fn(),
+  isIndividualLayout: false,
+  isDeviceRotationEnabled: true,
+};
+
+describe('Device Toolbar', () => {
+  it('disables screenshot buttons when javascript is disabled for the preview', () => {
+    render(
+      <Provider store={createStore()}>
+        <Toolbar {...baseProps} isJavaScriptDisabled />
+      </Provider>
+    );
+
+    const disabledButtons = screen.getAllByTitle(
+      'Screenshots are unavailable while JavaScript is disabled for this preview'
+    );
+
+    expect(disabledButtons).toHaveLength(2);
+    disabledButtons.forEach((button) => {
+      expect(button).toBeDisabled();
+    });
+  });
+});

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -1,6 +1,8 @@
 import {Icon} from '@iconify/react';
 import {useState} from 'react';
+import {useDispatch} from 'react-redux';
 import Button from 'renderer/components/Button';
+import {DropDown} from 'renderer/components/DropDown';
 import useSound from 'use-sound';
 import {ScreenshotArgs, ScreenshotResult} from 'main/screenshot';
 import {Device} from 'common/deviceList';
@@ -8,12 +10,14 @@ import WebPage from 'main/screenshot/webpage';
 
 import screenshotSfx from 'renderer/assets/sfx/screenshot.mp3';
 import {updateWebViewHeightAndScale} from 'common/webViewUtils';
+import {setDeviceJavaScriptDisabled} from 'renderer/store/features/javascript';
 import {ColorBlindnessTools} from './ColorBlindnessTools';
 import DesignOverlayControls from './DesignOverlayControls';
 
 interface Props {
   webview: Electron.WebviewTag | null;
   device: Device;
+  isJavaScriptDisabled: boolean;
   setScreenshotInProgress: (value: boolean) => void;
   openDevTools: () => void;
   toggleRuler: () => void;
@@ -26,6 +30,7 @@ interface Props {
 const Toolbar = ({
   webview,
   device,
+  isJavaScriptDisabled,
   setScreenshotInProgress,
   openDevTools,
   toggleRuler,
@@ -34,12 +39,15 @@ const Toolbar = ({
   isIndividualLayout,
   isDeviceRotationEnabled,
 }: Props) => {
+  const dispatch = useDispatch();
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, {volume: 0.5});
   const [screenshotLoading, setScreenshotLoading] = useState<boolean>(false);
   const [fullScreenshotLoading, setFullScreenshotLoading] = useState<boolean>(false);
   const [rotated, setRotated] = useState<boolean>(false);
   const [isDesignOverlayModalOpen, setIsDesignOverlayModalOpen] = useState<boolean>(false);
+  const screenshotDisabledTitle =
+    'Screenshots are unavailable while JavaScript is disabled for this preview';
 
   const refreshView = () => {
     if (webview) {
@@ -68,7 +76,7 @@ const Toolbar = ({
   };
 
   const quickScreenshot = async () => {
-    if (webview === null) {
+    if (webview === null || isJavaScriptDisabled) {
       return;
     }
     setScreenshotLoading(true);
@@ -86,7 +94,7 @@ const Toolbar = ({
   };
 
   const fullScreenshot = async () => {
-    if (webview === null) {
+    if (webview === null || isJavaScriptDisabled) {
       return;
     }
     setFullScreenshotLoading(true);
@@ -139,13 +147,27 @@ const Toolbar = ({
     }
   };
 
+  const toggleJavaScript = () => {
+    dispatch(
+      setDeviceJavaScriptDisabled({
+        deviceId: device.id,
+        disabled: !isJavaScriptDisabled,
+      })
+    );
+  };
+
   return (
     <div className="flex items-center justify-between gap-1">
       <div className="my-1 inline-flex max-w-[78%] items-center gap-1 overflow-x-auto">
         <Button onClick={refreshView} title="Refresh This View">
           <Icon icon="ic:round-refresh" />
         </Button>
-        <Button onClick={quickScreenshot} isLoading={screenshotLoading} title="Quick Screenshot">
+        <Button
+          onClick={quickScreenshot}
+          isLoading={screenshotLoading}
+          disabled={isJavaScriptDisabled}
+          title={isJavaScriptDisabled ? screenshotDisabledTitle : 'Quick Screenshot'}
+        >
           <div className="relative h-4 w-4">
             <Icon icon="ic:outline-photo-camera" className="absolute left-0 top-0" />
             <Icon
@@ -158,7 +180,8 @@ const Toolbar = ({
         <Button
           onClick={fullScreenshot}
           isLoading={fullScreenshotLoading}
-          title="Full Page Screenshot"
+          disabled={isJavaScriptDisabled}
+          title={isJavaScriptDisabled ? screenshotDisabledTitle : 'Full Page Screenshot'}
         >
           <Icon icon="ic:outline-photo-camera" />
         </Button>
@@ -194,12 +217,29 @@ const Toolbar = ({
         </Button>
         <ColorBlindnessTools webview={webview} />
       </div>
-      <Button
-        onClick={() => onIndividualLayoutHandler(device)}
-        title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}
-      >
-        <Icon icon={isIndividualLayout ? 'ic:twotone-zoom-in-map' : 'ic:twotone-zoom-out-map'} />
-      </Button>
+      <div className="flex items-center gap-1">
+        <DropDown
+          showChevron={false}
+          label={
+            <>
+              <span className="sr-only">More options</span>
+              <Icon icon="carbon:overflow-menu-vertical" />
+            </>
+          }
+          options={[
+            {
+              label: isJavaScriptDisabled ? 'Enable JavaScript' : 'Disable JavaScript',
+              onClick: toggleJavaScript,
+            },
+          ]}
+        />
+        <Button
+          onClick={() => onIndividualLayoutHandler(device)}
+          title={`${isIndividualLayout ? 'Disable' : 'Enable'} Individual Layout`}
+        >
+          <Icon icon={isIndividualLayout ? 'ic:twotone-zoom-in-map' : 'ic:twotone-zoom-out-map'} />
+        </Button>
+      </div>
       <DesignOverlayControls
         device={device}
         isOpen={isDesignOverlayModalOpen}

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -42,7 +42,6 @@ import type {RootState} from '../../../store';
 import {selectDesignOverlay, type ViewResolution} from '../../../store/features/design-overlay';
 import {
   Coordinates,
-  RulersState,
   selectRuler,
   selectRulerEnabled,
   setRuler,
@@ -81,17 +80,23 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const devtoolsOpenForWebviewId = useSelector(selectDevtoolsWebviewId);
   const layout = useSelector(selectLayout);
-  const rulerEnabled = useSelector(selectRulerEnabled);
-  const getRuler = useSelector(selectRuler);
   const dispatch = useDispatch();
   const dockPosition = useSelector(selectDockPosition);
   const darkMode = useSelector(selectDarkMode);
-  const ref = useRef<Electron.WebviewTag>(null);
+  const ref = useRef<Electron.WebviewTag | null>(null);
+  const [webviewElement, setWebviewElement] = useState<Electron.WebviewTag | null>(null);
   const isNavigatingFromAddressBar = useRef<boolean>(false);
-  const [webviewReady, setWebviewReady] = useState<boolean>(false);
+  const webviewKey = `${device.id}-${isJavaScriptDisabled ? 'js-off' : 'js-on'}`;
+  const [readyWebviewKey, setReadyWebviewKey] = useState<string | null>(null);
+  const isCurrentWebviewReady = readyWebviewKey === webviewKey;
+  const allowPopups = (isPrimary ? 'true' : undefined) as unknown as boolean | undefined;
+  const setWebviewRef = useCallback((element: Electron.WebviewTag | null) => {
+    ref.current = element;
+    setWebviewElement(element);
+  }, []);
 
   useEffect(() => {
-    if (ref.current && isPrimary) {
+    if (ref.current && isPrimary && isCurrentWebviewReady) {
       try {
         const currentUrl = ref.current.getURL();
         if (address !== currentUrl) {
@@ -103,18 +108,20 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
         console.error('Error loading URL', err);
       }
     }
-  }, [address, isPrimary]);
+  }, [address, isPrimary, isCurrentWebviewReady, webviewElement]);
 
   useEffect(() => {
     const webview = ref.current;
     if (!webview) return undefined;
-    const onDomReady = () => setWebviewReady(true);
+    const onDomReady = () => setReadyWebviewKey(webviewKey);
     webview.addEventListener('dom-ready', onDomReady);
     return () => {
       webview.removeEventListener('dom-ready', onDomReady);
-      setWebviewReady(false);
+      setReadyWebviewKey((currentReadyWebviewKey) =>
+        currentReadyWebviewKey === webviewKey ? null : currentReadyWebviewKey
+      );
     };
-  }, [ref]);
+  }, [webviewKey]);
 
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
@@ -132,6 +139,8 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
 
   const resolution: ViewResolution = `${width}x${height}`;
   const designOverlay = useSelector((state: RootState) => selectDesignOverlay(state)(resolution));
+  const ruler = useSelector((state: RootState) => selectRuler(state)(resolution));
+  const isRulerEnabled = useSelector((state: RootState) => selectRulerEnabled(state)(resolution));
 
   const [coordinates, setCoordinates] = useState<Coordinates>({
     deltaX: 0,
@@ -142,66 +151,6 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     innerHeight: height * 2,
   });
 
-  const registerNavigationHandlers = useCallback(() => {
-    webViewPubSub.subscribe(NAVIGATION_EVENTS.RELOAD, () => {
-      if (ref.current) {
-        ref.current.reload();
-      }
-    });
-    if (isPrimary) {
-      webViewPubSub.subscribe(NAVIGATION_EVENTS.BACK, () => {
-        if (ref.current) {
-          ref.current.goBack();
-        }
-      });
-
-      webViewPubSub.subscribe(NAVIGATION_EVENTS.FORWARD, () => {
-        if (ref.current) {
-          ref.current.goForward();
-        }
-      });
-
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_STORAGE, async () => {
-        if (!ref.current) {
-          return;
-        }
-        const webview = ref.current as Electron.WebviewTag;
-        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
-          'delete-storage',
-          {webContentsId: webview.getWebContentsId()}
-        );
-      });
-
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_COOKIES, async () => {
-        if (!ref.current) {
-          return;
-        }
-        const webview = ref.current as Electron.WebviewTag;
-        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
-          'delete-storage',
-          {
-            webContentsId: webview.getWebContentsId(),
-            storages: ['cookies'],
-          }
-        );
-      });
-
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_CACHE, async () => {
-        if (!ref.current) {
-          return;
-        }
-        const webview = ref.current as Electron.WebviewTag;
-        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
-          'delete-storage',
-          {
-            webContentsId: webview.getWebContentsId(),
-            storages: ['network-cache'],
-          }
-        );
-      });
-    }
-  }, [isPrimary]);
-
   const toggleRuler = useCallback(() => {
     if (!ref.current) {
       return;
@@ -210,7 +159,6 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     if (webview == null) {
       return;
     }
-    const ruler: RulersState | undefined = getRuler(resolution);
     if (ruler) {
       dispatch(
         setRuler({
@@ -232,7 +180,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
         })
       );
     }
-  }, [dispatch, getRuler, coordinates, resolution]);
+  }, [dispatch, ruler, coordinates, resolution]);
 
   useKeyboardShortcut(SHORTCUT_CHANNEL.TOGGLE_RULERS, toggleRuler);
 
@@ -298,6 +246,57 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     }
     const webview = ref.current as Electron.WebviewTag;
     const handlerRemovers: (() => void)[] = [];
+    const pubSubRemovers: (() => void)[] = [];
+    const subscribeToWebViewChannel = (
+      topic: string,
+      handler: Parameters<typeof webViewPubSub.subscribe>[1]
+    ) => {
+      webViewPubSub.subscribe(topic, handler);
+      pubSubRemovers.push(() => {
+        webViewPubSub.unsubscribe(topic, handler);
+      });
+    };
+
+    subscribeToWebViewChannel(NAVIGATION_EVENTS.RELOAD, () => {
+      webview.reload();
+    });
+
+    if (isPrimary) {
+      subscribeToWebViewChannel(NAVIGATION_EVENTS.BACK, () => {
+        webview.goBack();
+      });
+
+      subscribeToWebViewChannel(NAVIGATION_EVENTS.FORWARD, () => {
+        webview.goForward();
+      });
+
+      subscribeToWebViewChannel(ADDRESS_BAR_EVENTS.DELETE_STORAGE, async () => {
+        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
+          'delete-storage',
+          {webContentsId: webview.getWebContentsId()}
+        );
+      });
+
+      subscribeToWebViewChannel(ADDRESS_BAR_EVENTS.DELETE_COOKIES, async () => {
+        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
+          'delete-storage',
+          {
+            webContentsId: webview.getWebContentsId(),
+            storages: ['cookies'],
+          }
+        );
+      });
+
+      subscribeToWebViewChannel(ADDRESS_BAR_EVENTS.DELETE_CACHE, async () => {
+        await window.electron.ipcRenderer.invoke<DeleteStorageArgs, DeleteStorageResult>(
+          'delete-storage',
+          {
+            webContentsId: webview.getWebContentsId(),
+            storages: ['network-cache'],
+          }
+        );
+      });
+    }
 
     const didNavigateHandler = (e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent) => {
       // Only DidNavigateInPageEvent has isMainFrame
@@ -402,27 +401,35 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     });
 
     if (!isPrimary) {
-      setTimeout(() => {
-        webview.addEventListener('dom-ready', () => {
-          window.electron.ipcRenderer.invoke<
-            DisableDefaultWindowOpenHandlerArgs,
-            DisableDefaultWindowOpenHandlerResult
-          >('disable-default-window-open-handler', {
-            webContentsId: webview.getWebContentsId(),
-          });
+      const disableDefaultWindowOpenHandler = () => {
+        window.electron.ipcRenderer.invoke<
+          DisableDefaultWindowOpenHandlerArgs,
+          DisableDefaultWindowOpenHandlerResult
+        >('disable-default-window-open-handler', {
+          webContentsId: webview.getWebContentsId(),
+        });
+      };
+      const disableDefaultWindowOpenHandlerTimeout = window.setTimeout(() => {
+        webview.addEventListener('dom-ready', disableDefaultWindowOpenHandler);
+        handlerRemovers.push(() => {
+          webview.removeEventListener('dom-ready', disableDefaultWindowOpenHandler);
         });
       }, 2000);
+      handlerRemovers.push(() => {
+        window.clearTimeout(disableDefaultWindowOpenHandlerTimeout);
+      });
     }
-
-    registerNavigationHandlers();
 
     // eslint-disable-next-line consistent-return
     return () => {
       handlerRemovers.forEach((handlerRemover) => {
         handlerRemover();
       });
+      pubSubRemovers.forEach((handlerRemover) => {
+        handlerRemover();
+      });
     };
-  }, [ref, dispatch, registerNavigationHandlers, isPrimary, inspectElement, openDevTools, address]);
+  }, [dispatch, isPrimary, inspectElement, openDevTools, webviewKey]);
 
   useEffect(() => {
     // Reload keyboard shortcuts effect
@@ -445,10 +452,10 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     return () => {
       window.electron.ipcRenderer.removeListener('reload', reloadHandler);
     };
-  }, [ref]);
+  }, [webviewKey]);
 
   useEffect(() => {
-    if (!ref.current || !webviewReady) {
+    if (!ref.current || !isCurrentWebviewReady) {
       return undefined;
     }
     const webview = ref.current as Electron.WebviewTag;
@@ -467,26 +474,21 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     window.electron.ipcRenderer.on('inspect-element', inspectElementHandler);
 
     return () => {
-      try {
-        window.electron.ipcRenderer.removeAllListeners('inspect-element');
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error('Error while removing ipc listener', e);
-      }
+      window.electron.ipcRenderer.removeListener('inspect-element', inspectElementHandler);
     };
   }, [
-    ref,
     dispatch,
     isDevtoolsOpen,
     devtoolsOpenForWebviewId,
     openDevTools,
     zoomfactor,
     inspectElement,
-    webviewReady,
+    isCurrentWebviewReady,
+    webviewKey,
   ]);
 
   useEffect(() => {
-    if (!ref.current || !webviewReady || isInspecting === undefined) {
+    if (!ref.current || !isCurrentWebviewReady || isInspecting === undefined) {
       return;
     }
     const webview = ref.current as Electron.WebviewTag;
@@ -498,7 +500,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
         }
       );
     })();
-  }, [isInspecting, webviewReady]);
+  }, [isInspecting, isCurrentWebviewReady]);
 
   useEffect(() => {
     if (!ref.current || !device.isMobileCapable) {
@@ -506,34 +508,37 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
     }
 
     const webview = ref.current;
-    webview.addEventListener('dom-ready', () => {
+    const insertScrollbarCss = () => {
       webview.insertCSS(`
                ::-webkit-scrollbar {
               display: none;
               } `);
-    });
+    };
+    webview.addEventListener('dom-ready', insertScrollbarCss);
 
     // eslint-disable-next-line consistent-return
     return () => {
-      webview.removeEventListener('dom-ready', () => {});
+      webview.removeEventListener('dom-ready', insertScrollbarCss);
     };
-  }, [device.isMobileCapable]);
+  }, [device.isMobileCapable, webviewKey]);
 
   useEffect(() => {
     const webview = ref.current;
 
     if (isPrimary && webview) {
-      webview.addEventListener('dom-ready', () => {
+      const updatePageTitle = () => {
         const pageTitle = webview.getTitle();
         dispatch(setPageTitle(pageTitle));
-      });
+      };
+      webview.addEventListener('dom-ready', updatePageTitle);
+
+      return () => {
+        webview.removeEventListener('dom-ready', updatePageTitle);
+      };
     }
 
-    // eslint-disable-next-line consistent-return
-    return () => {
-      webview?.removeEventListener('dom-ready', () => {});
-    };
-  }, [dispatch, isPrimary]);
+    return undefined;
+  }, [dispatch, isPrimary, webviewKey]);
 
   const scaledHeight = height * zoomfactor;
   const scaledWidth = width * zoomfactor;
@@ -557,7 +562,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
         {loading ? <Spinner spinnerHeight={24} /> : null}
       </div>
       <Toolbar
-        webview={ref.current}
+        webview={webviewElement}
         device={device}
         isJavaScriptDisabled={isJavaScriptDisabled}
         setScreenshotInProgress={setScreenshotInProgress}
@@ -571,8 +576,8 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
       <div className="flex gap-4">
         <div
           style={{
-            height: rulerEnabled(`${width}x${height}`) ? scaledHeight + 30 : scaledHeight,
-            width: rulerEnabled(`${width}x${height}`) ? scaledWidth + 30 : scaledWidth,
+            height: isRulerEnabled ? scaledHeight + 30 : scaledHeight,
+            width: isRulerEnabled ? scaledWidth + 30 : scaledWidth,
           }}
           className="relative origin-top-left overflow-hidden bg-white"
         >
@@ -584,7 +589,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
             coordinates={coordinates}
             zoomFactor={zoomfactor}
             night={darkMode}
-            enabled={rulerEnabled(`${width}x${height}`)}
+            enabled={isRulerEnabled}
             defaultGuides={window.electron.store
               .get('userPreferences.guides')
               .flatMap((x: unknown) => x as DefaultGuide[])
@@ -594,6 +599,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
           />
           <div className="bg-white">
             <webview
+              key={webviewKey}
               id={device.name}
               src={address}
               style={{
@@ -601,16 +607,16 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
                 width,
                 display: 'inline-flex',
                 transform: `scale(${zoomfactor})`,
-                marginLeft: rulerEnabled(`${width}x${height}`) ? '30px' : 0,
-                marginTop: rulerEnabled(`${width}x${height}`) ? '30px' : 0,
+                marginLeft: isRulerEnabled ? '30px' : 0,
+                marginTop: isRulerEnabled ? '30px' : 0,
               }}
-              ref={ref}
+              ref={setWebviewRef}
               className="origin-top-left"
               /* eslint-disable-next-line react/no-unknown-property */
               preload={`file://${window.responsively.webviewPreloadPath}`}
               data-scale-factor={zoomfactor}
               /* eslint-disable-next-line react/no-unknown-property */
-              allowpopups={isPrimary ? true : undefined}
+              allowpopups={allowPopups}
               /* eslint-disable-next-line react/no-unknown-property */
               useragent={device.userAgent}
               /* eslint-disable-next-line react/no-unknown-property */
@@ -628,7 +634,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
                 zoomFactor={zoomfactor}
                 coordinates={coordinates}
                 position={designOverlay.position}
-                rulerMargin={rulerEnabled(`${width}x${height}`) ? 30 : 0}
+                rulerMargin={isRulerEnabled ? 30 : 0}
                 width={width}
                 height={height}
               />
@@ -663,7 +669,7 @@ const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: 
             zoomFactor={zoomfactor}
             coordinates={coordinates}
             position={designOverlay.position}
-            rulerMargin={rulerEnabled(`${width}x${height}`) ? 30 : 0}
+            rulerMargin={isRulerEnabled ? 30 : 0}
             width={width}
             height={height}
           />

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -60,6 +60,7 @@ import {appendHistory} from './utils';
 interface Props {
   device: IDevice;
   isPrimary: boolean;
+  isJavaScriptDisabled: boolean;
   setIndividualDevice: (device: IDevice) => void;
 }
 
@@ -68,7 +69,7 @@ interface ErrorState {
   description: string;
 }
 
-const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
+const Device = ({isPrimary, isJavaScriptDisabled, device, setIndividualDevice}: Props) => {
   const [singleRotated, setSingleRotated] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ErrorState | null>(null);
@@ -558,6 +559,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       <Toolbar
         webview={ref.current}
         device={device}
+        isJavaScriptDisabled={isJavaScriptDisabled}
         setScreenshotInProgress={setScreenshotInProgress}
         openDevTools={openDevTools}
         toggleRuler={toggleRuler}
@@ -611,6 +613,8 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
               allowpopups={isPrimary ? true : undefined}
               /* eslint-disable-next-line react/no-unknown-property */
               useragent={device.userAgent}
+              /* eslint-disable-next-line react/no-unknown-property */
+              webpreferences={isJavaScriptDisabled ? 'javascript=no' : undefined}
             />
           </div>
 

--- a/desktop-app/src/renderer/components/Previewer/index.test.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.test.tsx
@@ -1,0 +1,125 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {act, render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import javascriptReducer, {setDeviceJavaScriptDisabled} from 'renderer/store/features/javascript';
+import Previewer from './index';
+
+const activeSuite = {
+  id: 'default',
+  name: 'Default',
+  devices: ['10008'],
+};
+
+const mountSpy = vi.hoisted(() => vi.fn());
+const unmountSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('common/deviceList', () => ({
+  getDevicesMap: () => ({
+    '10008': {
+      id: '10008',
+      name: 'iPhone XR',
+      width: 414,
+      height: 896,
+      userAgent: 'test-agent',
+      type: 'phone',
+      dpr: 2,
+      isTouchCapable: true,
+      isMobileCapable: true,
+      capabilities: ['touch', 'mobile'],
+    },
+  }),
+}));
+
+vi.mock('./Device', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const MockDevice = ({
+    device,
+    isJavaScriptDisabled,
+  }: {
+    device: {id: string};
+    isJavaScriptDisabled: boolean;
+  }) => {
+    React.useEffect(() => {
+      mountSpy(device.id);
+
+      return () => {
+        unmountSpy(device.id);
+      };
+    }, [device.id]);
+
+    return (
+      <div
+        data-testid={`device-${device.id}`}
+        data-javascript-disabled={String(isJavaScriptDisabled)}
+      />
+    );
+  };
+
+  return {
+    default: MockDevice,
+  };
+});
+
+vi.mock('renderer/store/features/device-manager', () => ({
+  selectActiveSuite: () => activeSuite,
+}));
+
+vi.mock('renderer/store/features/devtools', () => ({
+  selectDockPosition: () => 'RIGHT',
+  selectIsDevtoolsOpen: () => false,
+}));
+
+vi.mock('renderer/store/features/renderer', async () => {
+  const actual = await vi.importActual<typeof import('renderer/store/features/renderer')>(
+    'renderer/store/features/renderer'
+  );
+
+  return {
+    ...actual,
+    selectLayout: () => 'COLUMN',
+  };
+});
+
+vi.mock('./DevtoolsResizer', () => ({
+  default: () => null,
+}));
+
+vi.mock('./IndividualLayoutToolBar', () => ({
+  default: () => null,
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      javascript: javascriptReducer,
+    },
+  });
+
+describe('Previewer', () => {
+  beforeEach(() => {
+    mountSpy.mockClear();
+    unmountSpy.mockClear();
+  });
+
+  it('keeps the Device mounted when toggling javascript for the same preview', async () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <Previewer />
+      </Provider>
+    );
+
+    expect(mountSpy).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId('device-10008')).toHaveAttribute('data-javascript-disabled', 'false');
+
+    await act(async () => {
+      store.dispatch(setDeviceJavaScriptDisabled({deviceId: '10008', disabled: true}));
+    });
+
+    expect(mountSpy).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId('device-10008')).toHaveAttribute('data-javascript-disabled', 'true');
+  });
+});

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -25,7 +25,7 @@ interface MasonryProps {
   children: React.ReactNode;
 }
 
-const TypedMasonry: React.FC<MasonryProps> = Masonry as any;
+const TypedMasonry = Masonry as unknown as React.FC<MasonryProps>;
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
@@ -44,8 +44,6 @@ const Previewer = () => {
     fitWidth: true,
     transitionDuration: 0,
   };
-  const getDeviceRenderKey = (deviceId: string) =>
-    `${deviceId}-${disabledJavaScriptByDeviceId[deviceId] ? 'js-off' : 'js-on'}`;
 
   return (
     <div className="h-full">
@@ -69,7 +67,7 @@ const Previewer = () => {
             {isMasonryLayout ? (
               <TypedMasonry options={masonryOptions} className="w-full gap-4 p-2">
                 {devices.map((device) => (
-                  <div key={getDeviceRenderKey(device.id)} className="device-item p-4">
+                  <div key={device.id} className="device-item p-4">
                     <Device
                       device={device}
                       isPrimary={device.id === devices[0].id}
@@ -88,7 +86,7 @@ const Previewer = () => {
               >
                 {isIndividualLayout ? (
                   <Device
-                    key={getDeviceRenderKey(individualDevice.id)}
+                    key={individualDevice.id}
                     device={individualDevice}
                     isPrimary
                     isJavaScriptDisabled={Boolean(
@@ -99,7 +97,7 @@ const Previewer = () => {
                 ) : (
                   devices.map((device, idx) => (
                     <Device
-                      key={getDeviceRenderKey(device.id)}
+                      key={device.id}
                       device={device}
                       isPrimary={idx === 0}
                       isJavaScriptDisabled={Boolean(disabledJavaScriptByDeviceId[device.id])}

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -6,6 +6,7 @@ import {selectDockPosition, selectIsDevtoolsOpen} from 'renderer/store/features/
 import {getDevicesMap, Device as IDevice} from 'common/deviceList';
 import {useState} from 'react';
 import {selectLayout} from 'renderer/store/features/renderer';
+import {selectJavaScriptDisabledByDeviceId} from 'renderer/store/features/javascript';
 import Masonry from 'react-masonry-component';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
@@ -32,6 +33,7 @@ const Previewer = () => {
   const dockPosition = useSelector(selectDockPosition);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
   const isMasonryLayout = layout === PREVIEW_LAYOUTS.MASONRY; // New state for Masonry layout
@@ -42,6 +44,8 @@ const Previewer = () => {
     fitWidth: true,
     transitionDuration: 0,
   };
+  const getDeviceRenderKey = (deviceId: string) =>
+    `${deviceId}-${disabledJavaScriptByDeviceId[deviceId] ? 'js-off' : 'js-on'}`;
 
   return (
     <div className="h-full">
@@ -65,10 +69,11 @@ const Previewer = () => {
             {isMasonryLayout ? (
               <TypedMasonry options={masonryOptions} className="w-full gap-4 p-2">
                 {devices.map((device) => (
-                  <div key={device.id} className="device-item p-4">
+                  <div key={getDeviceRenderKey(device.id)} className="device-item p-4">
                     <Device
                       device={device}
                       isPrimary={device.id === devices[0].id}
+                      isJavaScriptDisabled={Boolean(disabledJavaScriptByDeviceId[device.id])}
                       setIndividualDevice={setIndividualDevice}
                     />
                   </div>
@@ -83,17 +88,21 @@ const Previewer = () => {
               >
                 {isIndividualLayout ? (
                   <Device
-                    key={individualDevice.id}
+                    key={getDeviceRenderKey(individualDevice.id)}
                     device={individualDevice}
                     isPrimary
+                    isJavaScriptDisabled={Boolean(
+                      disabledJavaScriptByDeviceId[individualDevice.id]
+                    )}
                     setIndividualDevice={setIndividualDevice}
                   />
                 ) : (
                   devices.map((device, idx) => (
                     <Device
-                      key={device.id}
+                      key={getDeviceRenderKey(device.id)}
                       device={device}
                       isPrimary={idx === 0}
+                      isJavaScriptDisabled={Boolean(disabledJavaScriptByDeviceId[device.id])}
                       setIndividualDevice={setIndividualDevice}
                     />
                   ))

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx
@@ -1,0 +1,41 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import javascriptReducer from 'renderer/store/features/javascript';
+import JavaScriptControls from './index';
+
+const activeSuite = {
+  id: 'default',
+  name: 'Default',
+  devices: ['10008', '10013'],
+};
+
+vi.mock('renderer/store/features/device-manager', () => ({
+  selectActiveSuite: () => activeSuite,
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      javascript: javascriptReducer,
+    },
+  });
+
+describe('JavaScriptControls', () => {
+  it('disables javascript for all active previews from the global menu', () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <JavaScriptControls />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(store.getState().javascript.disabledByDeviceId).toEqual({
+      '10008': true,
+      '10013': true,
+    });
+  });
+});

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.tsx
@@ -1,0 +1,37 @@
+import {useDispatch, useSelector} from 'react-redux';
+import Toggle from 'renderer/components/Toggle';
+import {selectActiveSuite} from 'renderer/store/features/device-manager';
+import {
+  selectJavaScriptDisabledByDeviceId,
+  setDevicesJavaScriptDisabled,
+} from 'renderer/store/features/javascript';
+
+const JavaScriptControls = () => {
+  const dispatch = useDispatch();
+  const activeSuite = useSelector(selectActiveSuite);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
+  const isEnabledForAllDevices = activeSuite.devices.every(
+    (deviceId) => !disabledJavaScriptByDeviceId[deviceId]
+  );
+
+  return (
+    <div className="flex flex-row items-center justify-start px-4">
+      <span className="w-1/2">JavaScript (All Previews)</span>
+      <div className="flex items-center gap-2 border-l px-4 dark:border-slate-400">
+        <Toggle
+          isOn={isEnabledForAllDevices}
+          onChange={(value) => {
+            dispatch(
+              setDevicesJavaScriptDisabled({
+                deviceIds: activeSuite.devices,
+                disabled: !value.target.checked,
+              })
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default JavaScriptControls;

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
@@ -5,6 +5,7 @@ import UITheme from './UITheme';
 import Zoom from './Zoom';
 import AllowInSecureSSL from './AllowInSecureSSL';
 import ClearHistory from './ClearHistory';
+import JavaScriptControls from './JavaScriptControls';
 import PreviewLayout from './PreviewLayout';
 import Bookmark from './Bookmark';
 import {Settings} from './Settings';
@@ -20,6 +21,7 @@ const MenuFlyout = ({closeFlyout}: Props) => {
       <UITheme />
       <Devtools />
       <AllowInSecureSSL />
+      <JavaScriptControls />
       <ClearHistory />
       <Divider />
 

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -6,10 +6,10 @@ import {
   setIsCapturingScreenshot,
   setIsInspecting,
   setRotate,
-  setNotifications,
 } from 'renderer/store/features/renderer';
 import {Icon} from '@iconify/react';
 import {ScreenshotAllArgs} from 'main/screenshot';
+import {selectJavaScriptDisabledByDeviceId} from 'renderer/store/features/javascript';
 import {selectActiveSuite} from 'renderer/store/features/device-manager';
 import WebPage from 'main/screenshot/webpage';
 import {getDevicesMap} from 'common/deviceList';
@@ -35,14 +35,21 @@ const ToolBar = () => {
   const isInspecting = useSelector(selectIsInspecting);
   const isCapturingScreenshot = useSelector(selectIsCapturingScreenshot);
   const activeSuite = useSelector(selectActiveSuite);
+  const disabledJavaScriptByDeviceId = useSelector(selectJavaScriptDisabledByDeviceId);
   const dispatch = useDispatch();
+  const isAnyJavaScriptDisabled = activeSuite.devices.some(
+    (deviceId) => disabledJavaScriptByDeviceId[deviceId]
+  );
+  const screenshotAllTitle = isAnyJavaScriptDisabled
+    ? 'Screenshot All WebViews is unavailable while JavaScript is disabled for one or more previews'
+    : 'Screenshot All WebViews';
 
   function handleInspectShortcut() {
     dispatch(setIsInspecting(!isInspecting));
   }
 
   const screenshotCaptureHandler = async () => {
-    if (isCapturingScreenshot) {
+    if (isCapturingScreenshot || isAnyJavaScriptDisabled) {
       return;
     }
 
@@ -114,7 +121,8 @@ const ToolBar = () => {
       <Button
         onClick={screenshotCaptureHandler}
         isActive={isCapturingScreenshot}
-        title="Screenshot All WebViews"
+        disabled={isAnyJavaScriptDisabled}
+        title={screenshotAllTitle}
       >
         <Icon icon="lucide:camera" />
       </Button>

--- a/desktop-app/src/renderer/store/features/javascript/index.test.ts
+++ b/desktop-app/src/renderer/store/features/javascript/index.test.ts
@@ -1,0 +1,54 @@
+import javascriptReducer, {
+  setDeviceJavaScriptDisabled,
+  setDevicesJavaScriptDisabled,
+  type JavaScriptState,
+} from './index';
+
+describe('javascriptSlice', () => {
+  it('disables and re-enables javascript for a single device', () => {
+    const initialState: JavaScriptState = {
+      disabledByDeviceId: {},
+    };
+
+    const disabledState = javascriptReducer(
+      initialState,
+      setDeviceJavaScriptDisabled({deviceId: '10008', disabled: true})
+    );
+
+    expect(disabledState.disabledByDeviceId).toEqual({
+      '10008': true,
+    });
+
+    const enabledState = javascriptReducer(
+      disabledState,
+      setDeviceJavaScriptDisabled({deviceId: '10008', disabled: false})
+    );
+
+    expect(enabledState.disabledByDeviceId).toEqual({});
+  });
+
+  it('toggles javascript for multiple devices at once', () => {
+    const initialState: JavaScriptState = {
+      disabledByDeviceId: {
+        '10008': true,
+      },
+    };
+
+    const disabledState = javascriptReducer(
+      initialState,
+      setDevicesJavaScriptDisabled({deviceIds: ['10008', '10013'], disabled: true})
+    );
+
+    expect(disabledState.disabledByDeviceId).toEqual({
+      '10008': true,
+      '10013': true,
+    });
+
+    const enabledState = javascriptReducer(
+      disabledState,
+      setDevicesJavaScriptDisabled({deviceIds: ['10008', '10013'], disabled: false})
+    );
+
+    expect(enabledState.disabledByDeviceId).toEqual({});
+  });
+});

--- a/desktop-app/src/renderer/store/features/javascript/index.ts
+++ b/desktop-app/src/renderer/store/features/javascript/index.ts
@@ -1,0 +1,52 @@
+import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import type {RootState} from '../..';
+
+export interface JavaScriptState {
+  disabledByDeviceId: Record<string, boolean>;
+}
+
+const initialState: JavaScriptState = {
+  disabledByDeviceId: {},
+};
+
+export const javascriptSlice = createSlice({
+  name: 'javascript',
+  initialState,
+  reducers: {
+    setDeviceJavaScriptDisabled: (
+      state,
+      action: PayloadAction<{deviceId: string; disabled: boolean}>
+    ) => {
+      const {deviceId, disabled} = action.payload;
+
+      if (disabled) {
+        state.disabledByDeviceId[deviceId] = true;
+        return;
+      }
+
+      delete state.disabledByDeviceId[deviceId];
+    },
+    setDevicesJavaScriptDisabled: (
+      state,
+      action: PayloadAction<{deviceIds: string[]; disabled: boolean}>
+    ) => {
+      const {deviceIds, disabled} = action.payload;
+
+      deviceIds.forEach((deviceId) => {
+        if (disabled) {
+          state.disabledByDeviceId[deviceId] = true;
+          return;
+        }
+
+        delete state.disabledByDeviceId[deviceId];
+      });
+    },
+  },
+});
+
+export const {setDeviceJavaScriptDisabled, setDevicesJavaScriptDisabled} = javascriptSlice.actions;
+
+export const selectJavaScriptDisabledByDeviceId = (state: RootState) =>
+  state.javascript.disabledByDeviceId;
+
+export default javascriptSlice.reducer;

--- a/desktop-app/src/renderer/store/index.ts
+++ b/desktop-app/src/renderer/store/index.ts
@@ -2,6 +2,7 @@ import {configureStore} from '@reduxjs/toolkit';
 
 import deviceManagerReducer from './features/device-manager';
 import devtoolsReducer from './features/devtools';
+import javascriptReducer from './features/javascript';
 import rendererReducer from './features/renderer';
 import rulersReducer from './features/ruler';
 import uiReducer from './features/ui';
@@ -13,6 +14,7 @@ export const store = configureStore({
     renderer: rendererReducer,
     ui: uiReducer,
     deviceManager: deviceManagerReducer,
+    javascript: javascriptReducer,
     devtools: devtoolsReducer,
     bookmarks: bookmarkReducer,
     rulers: rulersReducer,


### PR DESCRIPTION
## Summary
Add JavaScript toggle controls for device previews without remounting the React `Device` tree.

## Root cause
For #490, the `webview` must be recreated for JavaScript mode changes because `webpreferences` only take effect when the `webview` is created. The earlier implementation rebuilt the whole preview device subtree, which left stale listeners and stale webview references in follow-up flows.

## Changes
- keep each `Device` mounted and remount only the target `webview` when JavaScript is toggled
- refresh toolbar webview references and scope listener cleanup to the current webview instance
- keep screenshot actions disabled while JavaScript is disabled for a preview
- add a regression test to ensure toggling JavaScript does not remount `Device`

## Verification
- `npm run typecheck`
- `npx eslint src/renderer/components/Previewer/Device/index.tsx src/renderer/components/Previewer/index.tsx src/renderer/components/Previewer/index.test.tsx`
- `npm run test -- src/renderer/store/features/javascript/index.test.ts src/renderer/components/ToolBar/Menu/Flyout/JavaScriptControls/index.test.tsx src/renderer/components/Previewer/Device/Toolbar.test.tsx src/renderer/components/Previewer/index.test.tsx`
- `npm run test`
- manual Electron verification on 2026-03-25:
  - per-device JavaScript toggle remounts only the target `webview`
  - all-previews JavaScript toggle remounts all `webview`s
  - `Device` roots remain mounted in both flows
  - screenshot actions are disabled while JavaScript is off

Closes #490
