### PR TITLE
feat: allow customizing in-app keyboard shortcuts

### DIFF
--- a/desktop-app/e2e/tests/keyboard-shortcuts-modal.spec.ts
+++ b/desktop-app/e2e/tests/keyboard-shortcuts-modal.spec.ts
@@ -26,7 +26,7 @@ test.describe('Keyboard Shortcuts Modal', () => {
     }
 
     await expect(app.page.getByText('General Shortcuts')).toBeVisible();
-    await expect(app.page.getByText('Previewer Shorcuts')).toBeVisible();
+    await expect(app.page.getByText('Previewer Shortcuts')).toBeVisible();
   });
 
   test('shortcuts modal can be closed', async ({app}) => {

--- a/desktop-app/src/renderer/components/KeyboardShortcutsManager/constants.ts
+++ b/desktop-app/src/renderer/components/KeyboardShortcutsManager/constants.ts
@@ -20,7 +20,10 @@ export const SHORTCUT_CHANNEL = {
 
 export type ShortcutChannel = (typeof SHORTCUT_CHANNEL)[keyof typeof SHORTCUT_CHANNEL];
 
-export const SHORTCUT_KEYS: {[key in ShortcutChannel]: string[]} = {
+export type ShortcutBindings = {[key in ShortcutChannel]: string[]};
+export type ShortcutOverrides = Partial<ShortcutBindings>;
+
+export const SHORTCUT_KEYS: ShortcutBindings = {
   [SHORTCUT_CHANNEL.BACK]: ['alt+left'],
   [SHORTCUT_CHANNEL.BOOKMARK]: ['mod+d'],
   [SHORTCUT_CHANNEL.DELETE_ALL]: ['mod+alt+del', 'mod+alt+backspace'],
@@ -38,4 +41,53 @@ export const SHORTCUT_KEYS: {[key in ShortcutChannel]: string[]} = {
   [SHORTCUT_CHANNEL.TOGGLE_RULERS]: ['alt+r'],
   [SHORTCUT_CHANNEL.ZOOM_IN]: ['mod+=', 'mod++', 'mod+shift+='],
   [SHORTCUT_CHANNEL.ZOOM_OUT]: ['mod+-'],
+};
+
+export const NON_CUSTOMIZABLE_SHORTCUT_CHANNELS: ShortcutChannel[] = [SHORTCUT_CHANNEL.RELOAD];
+
+export const CUSTOMIZABLE_SHORTCUT_CHANNELS: ShortcutChannel[] = Object.values(
+  SHORTCUT_CHANNEL
+).filter((channel) => !NON_CUSTOMIZABLE_SHORTCUT_CHANNELS.includes(channel));
+
+export const SHORTCUT_CATEGORIES: {
+  id: number;
+  name: string;
+  channels: ShortcutChannel[];
+}[] = [
+  {
+    id: 0,
+    name: 'General Shortcuts',
+    channels: [
+      SHORTCUT_CHANNEL.BACK,
+      SHORTCUT_CHANNEL.BOOKMARK,
+      SHORTCUT_CHANNEL.DELETE_ALL,
+      SHORTCUT_CHANNEL.DELETE_CACHE,
+      SHORTCUT_CHANNEL.DELETE_COOKIES,
+      SHORTCUT_CHANNEL.DELETE_STORAGE,
+      SHORTCUT_CHANNEL.EDIT_URL,
+    ],
+  },
+  {
+    id: 1,
+    name: 'Previewer Shortcuts',
+    channels: [
+      SHORTCUT_CHANNEL.FORWARD,
+      SHORTCUT_CHANNEL.INSPECT_ELEMENTS,
+      SHORTCUT_CHANNEL.PREVIEW_LAYOUT,
+      SHORTCUT_CHANNEL.RELOAD,
+      SHORTCUT_CHANNEL.ROTATE_ALL,
+      SHORTCUT_CHANNEL.SCREENSHOT_ALL,
+      SHORTCUT_CHANNEL.THEME,
+      SHORTCUT_CHANNEL.TOGGLE_RULERS,
+      SHORTCUT_CHANNEL.ZOOM_IN,
+      SHORTCUT_CHANNEL.ZOOM_OUT,
+    ],
+  },
+];
+
+export const resolveShortcutBindings = (overrides: ShortcutOverrides = {}): ShortcutBindings => {
+  return (Object.keys(SHORTCUT_KEYS) as ShortcutChannel[]).reduce((bindings, channel) => {
+    bindings[channel] = overrides[channel] ?? SHORTCUT_KEYS[channel];
+    return bindings;
+  }, {} as ShortcutBindings);
 };

--- a/desktop-app/src/renderer/components/KeyboardShortcutsManager/index.tsx
+++ b/desktop-app/src/renderer/components/KeyboardShortcutsManager/index.tsx
@@ -1,14 +1,28 @@
-import {SHORTCUT_KEYS, ShortcutChannel} from './constants';
+import {useSelector} from 'react-redux';
+import {selectResolvedShortcutBindings} from 'renderer/store/features/shortcuts';
+import {ShortcutChannel} from './constants';
 import useMousetrapEmitter from './useMousetrapEmitter';
 
-const KeyboardShortcutsManager = () => {
-  // eslint-disable-next-line no-restricted-syntax
-  for (const [channel, keys] of Object.entries(SHORTCUT_KEYS)) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useMousetrapEmitter(keys, channel as ShortcutChannel);
-  }
+interface ShortcutBindingProps {
+  channel: ShortcutChannel;
+  keys: string[];
+}
 
+const ShortcutBinding = ({channel, keys}: ShortcutBindingProps) => {
+  useMousetrapEmitter(keys, channel);
   return null;
+};
+
+const KeyboardShortcutsManager = () => {
+  const shortcutBindings = useSelector(selectResolvedShortcutBindings);
+
+  return (
+    <>
+      {Object.entries(shortcutBindings).map(([channel, keys]) => (
+        <ShortcutBinding key={channel} channel={channel as ShortcutChannel} keys={keys} />
+      ))}
+    </>
+  );
 };
 
 export default KeyboardShortcutsManager;

--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx
@@ -1,32 +1,200 @@
+import {useEffect, useRef, useState} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import Button from 'renderer/components/Button';
+import {
+  CUSTOMIZABLE_SHORTCUT_CHANNELS,
+  ShortcutChannel,
+} from 'renderer/components/KeyboardShortcutsManager/constants';
+import {
+  clearShortcutOverride,
+  selectShortcutOverride,
+  setShortcutOverride,
+} from 'renderer/store/features/shortcuts';
+
 interface Props {
+  channel: ShortcutChannel;
   text: string[];
 }
 
-const ShortcutButton = ({text}: Props) => {
-  const btnText = text[0].split('+');
+const SPECIAL_CODE_MAP: {[key: string]: string} = {
+  ArrowDown: 'down',
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  ArrowUp: 'up',
+  Backspace: 'backspace',
+  Comma: ',',
+  Delete: 'del',
+  Equal: '=',
+  Minus: '-',
+  Period: '.',
+  Slash: '/',
+  Space: 'space',
+};
+
+const formatText = (value: string) => {
+  if (value === 'mod') {
+    if (navigator?.userAgent?.includes('Windows')) {
+      return 'Ctrl';
+    }
+    return '⌘';
+  }
+
+  if (value === 'alt') return 'Alt';
+  if (value === 'shift') return 'Shift';
+  if (value === 'del') return 'Del';
+  if (value === 'backspace') return 'Backspace';
+  if (value.length === 1) return value.toUpperCase();
+  return value;
+};
+
+const ShortcutPreview = ({shortcut}: {shortcut: string}) => {
+  const btnText = shortcut.split('+');
   const btnTextLength = btnText.length - 1;
 
-  const formatText = (value: string) => {
-    if (value === 'mod') {
-      if (navigator?.userAgent?.includes('Windows')) {
-        return `Ctrl`;
-      }
-      return `⌘`;
-    }
-
-    if (value.length === 1) return value.toUpperCase();
-    return value;
-  };
   return (
-    <div>
-      {btnText.map((value, i) => (
-        <span key={value}>
+    <span className="inline-flex items-center">
+      {btnText.map((value, index) => (
+        <span key={`${shortcut}-${value}-${index}`}>
           <span className="rounded border border-gray-200 bg-gray-100 px-[6px] py-[2px] text-xs font-semibold text-gray-800 dark:border-gray-500 dark:bg-gray-600 dark:text-gray-100">
             {formatText(value)}
           </span>
-          {i < btnTextLength && <span className="px-1">+</span>}
+          {index < btnTextLength && <span className="px-1">+</span>}
         </span>
       ))}
+    </span>
+  );
+};
+
+const normalizeShortcutFromEvent = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+  const segments = [];
+
+  if (event.ctrlKey || event.metaKey) {
+    segments.push('mod');
+  }
+  if (event.altKey) {
+    segments.push('alt');
+  }
+  if (event.shiftKey) {
+    segments.push('shift');
+  }
+
+  let key = SPECIAL_CODE_MAP[event.code];
+  if (!key && event.code.startsWith('Key')) {
+    key = event.code.slice(3).toLowerCase();
+  }
+  if (!key && event.code.startsWith('Digit')) {
+    key = event.code.slice(5);
+  }
+
+  if (!key) {
+    const normalizedKey = event.key.toLowerCase();
+    if (['control', 'meta', 'alt', 'shift'].includes(normalizedKey)) {
+      return null;
+    }
+    key = normalizedKey;
+  }
+
+  return [...segments, key].join('+');
+};
+
+const ShortcutButton = ({channel, text}: Props) => {
+  const dispatch = useDispatch();
+  const shortcutOverride = useSelector(selectShortcutOverride(channel));
+  const isCustomizable = CUSTOMIZABLE_SHORTCUT_CHANNELS.includes(channel);
+  const isOverridden = shortcutOverride != null;
+  const [isCapturing, setIsCapturing] = useState(false);
+  const captureButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (isCapturing) {
+      captureButtonRef.current?.focus();
+    }
+  }, [isCapturing]);
+
+  const handleStartCapture = () => {
+    if (!isCustomizable) {
+      return;
+    }
+    setIsCapturing(true);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === 'Escape') {
+      setIsCapturing(false);
+      return;
+    }
+
+    const shortcut = normalizeShortcutFromEvent(event);
+    if (!shortcut) {
+      return;
+    }
+
+    dispatch(
+      setShortcutOverride({
+        channel,
+        keys: [shortcut],
+      })
+    );
+    setIsCapturing(false);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {isCapturing ? (
+        <button
+          ref={captureButtonRef}
+          type="button"
+          onKeyDown={handleKeyDown}
+          data-testid={`shortcut-${channel}-capture`}
+          className="rounded border border-emerald-500 bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-900 focus:outline-none dark:bg-emerald-900/30 dark:text-emerald-100"
+        >
+          Press shortcut
+        </button>
+      ) : (
+        <div className="flex flex-wrap items-center gap-1">
+          {text.map((shortcut, index) => (
+            <span key={`${channel}-${shortcut}-${index}`}>
+              <ShortcutPreview shortcut={shortcut} />
+              {index < text.length - 1 ? (
+                <span className="px-1 text-xs text-slate-500 dark:text-slate-300">/</span>
+              ) : null}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {isCustomizable ? (
+        <div className="flex items-center gap-1">
+          {isCapturing ? (
+            <Button className="px-2 text-xs" isTextButton onClick={() => setIsCapturing(false)}>
+              Cancel
+            </Button>
+          ) : (
+            <Button
+              className="px-2 text-xs"
+              isTextButton
+              onClick={handleStartCapture}
+              data-testid={`shortcut-${channel}-edit`}
+            >
+              {isOverridden ? 'Change' : 'Edit'}
+            </Button>
+          )}
+          {isOverridden && !isCapturing ? (
+            <Button
+              className="px-2 text-xs"
+              isTextButton
+              onClick={() => dispatch(clearShortcutOverride(channel))}
+              data-testid={`shortcut-${channel}-reset`}
+            >
+              Reset
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <span className="text-xs text-slate-500 dark:text-slate-300">Fixed</span>
+      )}
     </div>
   );
 };

--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutName.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutName.tsx
@@ -3,7 +3,7 @@ interface Props {
 }
 
 const ShortcutName = ({text}: Props) => {
-  const formattedText = text.replace('_', ' ').toLowerCase();
+  const formattedText = text.replace(/_/g, ' ').toLowerCase();
   return <div className="capitalize">{formattedText}</div>;
 };
 

--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.test.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.test.tsx
@@ -1,0 +1,91 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {type ReactNode} from 'react';
+import {Provider} from 'react-redux';
+import {type Mock} from 'vitest';
+import shortcutsReducer from 'renderer/store/features/shortcuts';
+import {SHORTCUT_CHANNEL} from 'renderer/components/KeyboardShortcutsManager/constants';
+import ShortcutsModal from './index';
+
+vi.mock('renderer/components/Modal', () => ({
+  default: ({isOpen, children}: {isOpen: boolean; children?: ReactNode}) =>
+    isOpen ? <div>{children}</div> : null,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window.electron.store.get as Mock).mockImplementation((key: string) => {
+    if (key === 'userPreferences.shortcuts') {
+      return {};
+    }
+    return undefined;
+  });
+});
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      shortcuts: shortcutsReducer,
+    },
+  });
+
+describe('ShortcutsModal', () => {
+  it('captures and stores a custom shortcut for a supported action', () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <ShortcutsModal isOpen onClose={() => undefined} />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByTestId('shortcut-THEME-edit'));
+    fireEvent.keyDown(screen.getByTestId('shortcut-THEME-capture'), {
+      code: 'KeyY',
+      key: 'y',
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(store.getState().shortcuts[SHORTCUT_CHANNEL.THEME]).toEqual(['mod+shift+y']);
+    expect(window.electron.store.set).toHaveBeenCalledWith('userPreferences.shortcuts', {
+      [SHORTCUT_CHANNEL.THEME]: ['mod+shift+y'],
+    });
+    expect(screen.getByTestId('shortcut-THEME-reset')).toBeInTheDocument();
+  });
+
+  it('resets a customized shortcut back to defaults', () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <ShortcutsModal isOpen onClose={() => undefined} />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByTestId('shortcut-THEME-edit'));
+    fireEvent.keyDown(screen.getByTestId('shortcut-THEME-capture'), {
+      code: 'KeyY',
+      key: 'y',
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    fireEvent.click(screen.getByTestId('shortcut-THEME-reset'));
+
+    expect(store.getState().shortcuts[SHORTCUT_CHANNEL.THEME]).toBeUndefined();
+    expect(window.electron.store.set).toHaveBeenLastCalledWith('userPreferences.shortcuts', {});
+  });
+
+  it('keeps reload fixed and non-editable', () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <ShortcutsModal isOpen onClose={() => undefined} />
+      </Provider>
+    );
+
+    expect(screen.queryByTestId('shortcut-RELOAD-edit')).not.toBeInTheDocument();
+    expect(screen.getByText('Fixed')).toBeInTheDocument();
+  });
+});

--- a/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.tsx
@@ -1,6 +1,11 @@
-import {SHORTCUT_KEYS} from 'renderer/components/KeyboardShortcutsManager/constants';
+import {useSelector} from 'react-redux';
+import {
+  SHORTCUT_CATEGORIES,
+  SHORTCUT_KEYS,
+} from 'renderer/components/KeyboardShortcutsManager/constants';
 import Modal from 'renderer/components/Modal';
 import Button from 'renderer/components/Button';
+import {selectResolvedShortcutBindings} from 'renderer/store/features/shortcuts';
 import ShortcutName from './ShortcutName';
 import ShortcutButton from './ShortcutButton';
 
@@ -9,31 +14,27 @@ interface Props {
   onClose: () => void;
 }
 
-export const shortcutsList = [
-  {
-    id: 0,
-    name: 'General Shortcuts',
-    shortcuts: Object.entries(SHORTCUT_KEYS).splice(0, 7),
-  },
-  {
-    id: 1,
-    name: 'Previewer Shorcuts',
-    shortcuts: Object.entries(SHORTCUT_KEYS).splice(7),
-  },
-];
-
 const ShortcutsModal = ({isOpen, onClose}: Props) => {
+  const shortcutBindings = useSelector(selectResolvedShortcutBindings);
+
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose}>
-        <div className="flex w-[380px] flex-col gap-4 px-2">
-          {Object.values(shortcutsList).map((category) => (
+        <div className="flex w-[520px] flex-col gap-4 px-2">
+          <p className="text-xs text-slate-600 dark:text-slate-300">
+            In-app shortcuts can be customized here. Reload stays fixed for now because it is still
+            handled by the application menu accelerator.
+          </p>
+          {SHORTCUT_CATEGORIES.map((category) => (
             <div key={category.id}>
               <h3 className="mb-3 border-b border-slate-600 pb-1 text-lg">{category.name}</h3>
-              {category.shortcuts.map((value) => (
-                <div className="my-2.5 flex justify-between" key={value[0]}>
-                  <ShortcutName text={value[0]} />
-                  <ShortcutButton text={value[1]} />
+              {category.channels.map((channel) => (
+                <div className="my-2.5 flex items-center justify-between gap-4" key={channel}>
+                  <ShortcutName text={channel} />
+                  <ShortcutButton
+                    channel={channel}
+                    text={shortcutBindings[channel] ?? SHORTCUT_KEYS[channel]}
+                  />
                 </div>
               ))}
             </div>

--- a/desktop-app/src/renderer/store/features/shortcuts/index.test.ts
+++ b/desktop-app/src/renderer/store/features/shortcuts/index.test.ts
@@ -1,0 +1,91 @@
+import {configureStore} from '@reduxjs/toolkit';
+import {type Mock} from 'vitest';
+import {
+  SHORTCUT_CHANNEL,
+  SHORTCUT_KEYS,
+  resolveShortcutBindings,
+} from 'renderer/components/KeyboardShortcutsManager/constants';
+import shortcutsReducer, {
+  clearShortcutOverride,
+  selectResolvedShortcutBindings,
+  setShortcutOverride,
+} from './index';
+
+const mockStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window.electron.store.get as Mock) = mockStore.get;
+  (window.electron.store.set as Mock) = mockStore.set;
+  mockStore.get.mockReturnValue({});
+});
+
+describe('shortcutsSlice', () => {
+  const createStore = () =>
+    configureStore({
+      reducer: {
+        shortcuts: shortcutsReducer,
+      },
+    });
+
+  it('loads persisted overrides from electron store', async () => {
+    vi.resetModules();
+    mockStore.get.mockReturnValue({
+      [SHORTCUT_CHANNEL.BOOKMARK]: ['mod+shift+b'],
+    });
+
+    const {default: reducer} = await import('./index');
+    const store = configureStore({
+      reducer: {
+        shortcuts: reducer,
+      },
+    });
+
+    expect(store.getState().shortcuts[SHORTCUT_CHANNEL.BOOKMARK]).toEqual(['mod+shift+b']);
+  });
+
+  it('persists a shortcut override', () => {
+    const store = createStore();
+
+    store.dispatch(
+      setShortcutOverride({
+        channel: SHORTCUT_CHANNEL.THEME,
+        keys: ['mod+shift+y'],
+      })
+    );
+
+    expect(store.getState().shortcuts[SHORTCUT_CHANNEL.THEME]).toEqual(['mod+shift+y']);
+    expect(mockStore.set).toHaveBeenCalledWith('userPreferences.shortcuts', {
+      [SHORTCUT_CHANNEL.THEME]: ['mod+shift+y'],
+    });
+  });
+
+  it('clears a shortcut override and falls back to defaults', () => {
+    const store = createStore();
+
+    store.dispatch(
+      setShortcutOverride({
+        channel: SHORTCUT_CHANNEL.THEME,
+        keys: ['mod+shift+y'],
+      })
+    );
+    store.dispatch(clearShortcutOverride(SHORTCUT_CHANNEL.THEME));
+
+    expect(store.getState().shortcuts[SHORTCUT_CHANNEL.THEME]).toBeUndefined();
+    expect(mockStore.set).toHaveBeenLastCalledWith('userPreferences.shortcuts', {});
+    expect(resolveShortcutBindings(store.getState().shortcuts)[SHORTCUT_CHANNEL.THEME]).toEqual(
+      SHORTCUT_KEYS[SHORTCUT_CHANNEL.THEME]
+    );
+  });
+
+  it('memoizes resolved shortcut bindings for unchanged state', () => {
+    const state = {shortcuts: {}} as unknown as Parameters<
+      typeof selectResolvedShortcutBindings
+    >[0];
+
+    expect(selectResolvedShortcutBindings(state)).toBe(selectResolvedShortcutBindings(state));
+  });
+});

--- a/desktop-app/src/renderer/store/features/shortcuts/index.ts
+++ b/desktop-app/src/renderer/store/features/shortcuts/index.ts
@@ -1,0 +1,88 @@
+import {createSelector, createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {
+  resolveShortcutBindings,
+  SHORTCUT_CHANNEL,
+  ShortcutBindings,
+  ShortcutChannel,
+  ShortcutOverrides,
+} from 'renderer/components/KeyboardShortcutsManager/constants';
+import type {RootState} from '../..';
+
+const SHORTCUTS_STORE_KEY = 'userPreferences.shortcuts';
+
+const isShortcutChannel = (value: string): value is ShortcutChannel =>
+  Object.values(SHORTCUT_CHANNEL).includes(value as ShortcutChannel);
+
+const loadPersistedShortcutOverrides = (): ShortcutOverrides => {
+  try {
+    const persisted = window.electron.store.get(SHORTCUTS_STORE_KEY);
+    if (persisted == null || typeof persisted !== 'object') {
+      return {};
+    }
+
+    return Object.entries(persisted as Record<string, unknown>).reduce(
+      (overrides, [channel, keys]) => {
+        if (
+          !isShortcutChannel(channel) ||
+          !Array.isArray(keys) ||
+          keys.some((key) => typeof key !== 'string')
+        ) {
+          return overrides;
+        }
+
+        overrides[channel] = keys;
+        return overrides;
+      },
+      {} as ShortcutOverrides
+    );
+  } catch {
+    return {};
+  }
+};
+
+const persistShortcutOverrides = (overrides: ShortcutOverrides) => {
+  window.electron.store.set(SHORTCUTS_STORE_KEY, overrides);
+};
+
+const initialState: ShortcutOverrides = loadPersistedShortcutOverrides();
+
+export const shortcutsSlice = createSlice({
+  name: 'shortcuts',
+  initialState,
+  reducers: {
+    setShortcutOverride: (
+      state,
+      action: PayloadAction<{
+        channel: ShortcutChannel;
+        keys: string[];
+      }>
+    ) => {
+      state[action.payload.channel] = action.payload.keys;
+      persistShortcutOverrides({
+        ...state,
+        [action.payload.channel]: action.payload.keys,
+      });
+    },
+    clearShortcutOverride: (state, action: PayloadAction<ShortcutChannel>) => {
+      delete state[action.payload];
+
+      const nextOverrides = {...state};
+      delete nextOverrides[action.payload];
+      persistShortcutOverrides(nextOverrides);
+    },
+  },
+});
+
+export const {setShortcutOverride, clearShortcutOverride} = shortcutsSlice.actions;
+
+export const selectShortcutOverrides = (state: RootState) => state.shortcuts;
+export const selectResolvedShortcutBindings = createSelector(
+  [selectShortcutOverrides],
+  (overrides): ShortcutBindings => resolveShortcutBindings(overrides)
+);
+export const selectShortcutOverride =
+  (channel: ShortcutChannel) =>
+  (state: RootState): string[] | undefined =>
+    state.shortcuts[channel];
+
+export default shortcutsSlice.reducer;

--- a/desktop-app/src/renderer/store/index.ts
+++ b/desktop-app/src/renderer/store/index.ts
@@ -4,6 +4,7 @@ import deviceManagerReducer from './features/device-manager';
 import devtoolsReducer from './features/devtools';
 import rendererReducer from './features/renderer';
 import rulersReducer from './features/ruler';
+import shortcutsReducer from './features/shortcuts';
 import uiReducer from './features/ui';
 import bookmarkReducer from './features/bookmarks';
 import designOverlayReducer from './features/design-overlay';
@@ -17,6 +18,7 @@ export const store = configureStore({
     bookmarks: bookmarkReducer,
     rulers: rulersReducer,
     designOverlay: designOverlayReducer,
+    shortcuts: shortcutsReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
Add renderer-side shortcut customization for the existing in-app shortcuts manager.

## Root cause
Keyboard bindings were hard-coded in the renderer, so users could not override the in-app shortcuts without changing source. The shortcuts modal was also read-only, which meant there was no narrow UI path for storing per-action overrides while keeping Electron menu accelerators untouched.

## Changes
- add a renderer shortcuts slice that loads and persists shortcut overrides through `window.electron.store`
- resolve keyboard bindings from defaults plus overrides before registering Mousetrap handlers and rendering the shortcuts modal
- turn the shortcuts modal into an editor with capture, reset, and fixed-state handling, while keeping `Reload` non-customizable because the application menu accelerator still owns it
- add targeted tests for persistence, memoized binding resolution, modal editing, reset behavior, and the fixed `Reload` row

## Verification
- `npm run typecheck`
- `npx eslint src/renderer/components/KeyboardShortcutsManager/constants.ts src/renderer/components/KeyboardShortcutsManager/index.tsx src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutButton.tsx src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/ShortcutName.tsx src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.tsx src/renderer/store/index.ts src/renderer/store/features/shortcuts/index.ts src/renderer/store/features/shortcuts/index.test.ts src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.test.tsx`
- `npm run test -- src/renderer/store/features/shortcuts/index.test.ts src/renderer/components/ToolBar/Shortcuts/ShortcutsModal/index.test.tsx`
- `npm run test`
- Electron verification:
  - opened `View Shortcuts` in the running Electron app and confirmed the modal exposes editable in-app shortcut rows
  - confirmed the `Reload` row stays `Fixed` with no edit control
  - captured a custom `Ctrl+Shift+Y` binding for `Theme` and verified `userPreferences.shortcuts.THEME` was written to `%APPDATA%\Electron\config.json`
  - triggered the new `Ctrl+Shift+Y` shortcut in the Electron app and verified `ui.darkMode` flipped to `true`, then reset the override and restored `ui.darkMode` to `false`

Closes #745
