### PR TITLE
Fixed horizontal tab scrollbar size & incorrect scroll range #1403

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
@@ -40,7 +40,7 @@ const IndividualLayoutToolbar = ({individualDevice, setIndividualDevice, devices
       >
         <TabList
           className={cx(
-            'custom-scrollbar flex w-full max-w-full overflow-x-auto overflow-y-hidden scroll-smooth whitespace-nowrap'
+            'custom-scrollbar flex w-full max-w-full gap-1 overflow-x-auto overflow-y-hidden scroll-smooth whitespace-nowrap border-b border-slate-400/60 dark:border-white'
           )}
         >
           {devices.map((device, idx) => (

--- a/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx
@@ -32,15 +32,15 @@ const IndividualLayoutToolbar = ({individualDevice, setIndividualDevice, devices
   }, [individualDevice, devices]);
 
   return (
-    <div className="my-4 ml-12 mr-4 flex justify-between">
+    <div className="overflow-x overflow-y my-4 ml-12 mr-4 flex justify-between whitespace-nowrap">
       <Tabs
         onSelect={onTabClick}
         selectedIndex={activeTab}
-        className={cx('react-tabs flex flex-1')}
+        className={cx('react-tabs flex flex-1 overflow-x-auto')}
       >
         <TabList
           className={cx(
-            'custom-scrollbar flex flex-1  justify-center gap-1 overflow-x-auto border-b border-slate-400/60 dark:border-white'
+            'custom-scrollbar flex w-full max-w-full overflow-x-auto overflow-y-hidden scroll-smooth whitespace-nowrap'
           )}
         >
           {devices.map((device, idx) => (


### PR DESCRIPTION
#


ℹ️ About the PR

Fixes #1403

### Problem
When we go into full screen mode of any type of display screen in the app and when we have more than 12 screens open in the app first screen goes inside the left window in tab pane. So, it made very difficult to switch to it i.e initial items got clipped and user is not able to view.

### Root Cause
Tabs were shrinking (flex-shrink: 1), reducing actual scrollable width
Missing whitespace-nowrap allowed layout inconsistencies
Scroll container width calculation was incorrect → browser rendered oversized scrollbar thumb

### Impact
No breaking changes.
Only CSS fixes.

### Changes
desktop-app/src/renderer/components/Previewer/IndividualLayoutToolBar/index.tsx


### 🖼️ Testing Scenarios / Screenshots


- Tested scroll from left. All initial items are now visible.
- Tested scroll from right. Full scrolling until the very end.
- Confirmed with going into full screen from multiple devices( Start, middle, end).

With full screen
<img width="1728" height="1117" alt="in-full-screen" src="https://github.com/user-attachments/assets/56d0dac8-cded-47eb-a38f-4b734d81d588" />

without full screen
<img width="1728" height="1117" alt="without-full-screen" src="https://github.com/user-attachments/assets/92744ad7-c83a-494d-8074-09abbe0a02fd" />


