### PR TITLE
fix(webview): stop URL bar revert and pubsub handler leak (#1482)

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -88,13 +88,19 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const ref = useRef<Electron.WebviewTag>(null);
   const isNavigatingFromAddressBar = useRef<boolean>(false);
   const [webviewReady, setWebviewReady] = useState<boolean>(false);
+  // Captured once on mount: the <webview> src attribute is set only on initial render,
+  // and all subsequent navigations go through loadURL below. Reactive src updates were
+  // racing with loadURL on Electron 40+, leaving the webview stuck on the previous URL.
+  const [initialAddress] = useState(address);
 
   useEffect(() => {
-    if (ref.current && isPrimary) {
+    if (ref.current) {
       try {
         const currentUrl = ref.current.getURL();
         if (address !== currentUrl) {
-          isNavigatingFromAddressBar.current = true;
+          if (isPrimary) {
+            isNavigatingFromAddressBar.current = true;
+          }
           ref.current.loadURL(address);
         }
       } catch (err) {
@@ -141,26 +147,40 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     innerHeight: height * 2,
   });
 
-  const registerNavigationHandlers = useCallback(() => {
-    webViewPubSub.subscribe(NAVIGATION_EVENTS.RELOAD, () => {
+  const registerNavigationHandlers = useCallback((): (() => void) => {
+    // Return an unsubscribe fn so the caller can clean up. Without this, every effect
+    // re-run (which happens on every address change) would add another subscriber, and a
+    // single Back click would replay accumulated handlers.
+    const unsubscribers: Array<() => void> = [];
+
+    const reloadHandler = () => {
       if (ref.current) {
         ref.current.reload();
       }
-    });
+    };
+    webViewPubSub.subscribe(NAVIGATION_EVENTS.RELOAD, reloadHandler);
+    unsubscribers.push(() => webViewPubSub.unsubscribe(NAVIGATION_EVENTS.RELOAD, reloadHandler));
+
     if (isPrimary) {
-      webViewPubSub.subscribe(NAVIGATION_EVENTS.BACK, () => {
+      const backHandler = () => {
         if (ref.current) {
           ref.current.goBack();
         }
-      });
+      };
+      webViewPubSub.subscribe(NAVIGATION_EVENTS.BACK, backHandler);
+      unsubscribers.push(() => webViewPubSub.unsubscribe(NAVIGATION_EVENTS.BACK, backHandler));
 
-      webViewPubSub.subscribe(NAVIGATION_EVENTS.FORWARD, () => {
+      const forwardHandler = () => {
         if (ref.current) {
           ref.current.goForward();
         }
-      });
+      };
+      webViewPubSub.subscribe(NAVIGATION_EVENTS.FORWARD, forwardHandler);
+      unsubscribers.push(() =>
+        webViewPubSub.unsubscribe(NAVIGATION_EVENTS.FORWARD, forwardHandler)
+      );
 
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_STORAGE, async () => {
+      const deleteStorageHandler = async () => {
         if (!ref.current) {
           return;
         }
@@ -169,9 +189,13 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
           'delete-storage',
           {webContentsId: webview.getWebContentsId()}
         );
-      });
+      };
+      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_STORAGE, deleteStorageHandler);
+      unsubscribers.push(() =>
+        webViewPubSub.unsubscribe(ADDRESS_BAR_EVENTS.DELETE_STORAGE, deleteStorageHandler)
+      );
 
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_COOKIES, async () => {
+      const deleteCookiesHandler = async () => {
         if (!ref.current) {
           return;
         }
@@ -183,9 +207,13 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
             storages: ['cookies'],
           }
         );
-      });
+      };
+      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_COOKIES, deleteCookiesHandler);
+      unsubscribers.push(() =>
+        webViewPubSub.unsubscribe(ADDRESS_BAR_EVENTS.DELETE_COOKIES, deleteCookiesHandler)
+      );
 
-      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_CACHE, async () => {
+      const deleteCacheHandler = async () => {
         if (!ref.current) {
           return;
         }
@@ -197,8 +225,14 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
             storages: ['network-cache'],
           }
         );
-      });
+      };
+      webViewPubSub.subscribe(ADDRESS_BAR_EVENTS.DELETE_CACHE, deleteCacheHandler);
+      unsubscribers.push(() =>
+        webViewPubSub.unsubscribe(ADDRESS_BAR_EVENTS.DELETE_CACHE, deleteCacheHandler)
+      );
     }
+
+    return () => unsubscribers.forEach((fn) => fn());
   }, [isPrimary]);
 
   const toggleRuler = useCallback(() => {
@@ -413,13 +447,14 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       }, 2000);
     }
 
-    registerNavigationHandlers();
+    const unsubscribeNavigationHandlers = registerNavigationHandlers();
 
     // eslint-disable-next-line consistent-return
     return () => {
       handlerRemovers.forEach((handlerRemover) => {
         handlerRemover();
       });
+      unsubscribeNavigationHandlers();
     };
   }, [ref, dispatch, registerNavigationHandlers, isPrimary, inspectElement, openDevTools, address]);
 
@@ -593,7 +628,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
           <div className="bg-white">
             <webview
               id={device.name}
-              src={address}
+              src={initialAddress}
               style={{
                 height,
                 width,


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Fixes: #1482

---

### ℹ️ About the PR

Two related fixes for `desktop-app/src/renderer/components/Previewer/Device/index.tsx`. They are independent in scope but small enough to review together.

#### 🐛 Bug 1 — Address bar URL revert (the user-visible #1482 symptom)

The webview is bound twice to the Redux `address`:

1. JSX: `<webview src={address} ... />` — React updates the `src` attribute whenever Redux changes.
2. `useEffect`: `ref.current.loadURL(address)` — also calls `loadURL` whenever Redux changes.

After Electron 40 (#1473), these two paths race for primary devices, and for non-primary devices the `useEffect` was guarded by `isPrimary`, leaving secondary previews navigating only via `src` reactivity. The end result on Linux/Windows builds was the webview getting wedged on the first URL — typing a new URL in the address bar dispatches `setAddress`, but `<webview>` does not actually navigate.

**Fix:** Drop reactive `src` updates and route every navigation through `loadURL`:

- Capture the address once on mount as `initialAddress` and pass that to `<webview src>`.
- Remove the `isPrimary` guard from the `loadURL` effect so secondary devices stay in sync too. The `isNavigatingFromAddressBar` flag remains primary-only because only the primary device's webview drives address-bar state.

This matches the approach in #1486; this PR is a clean version that does not also delete `release/app/{package.json,package-lock.json,yarn.lock}`.

#### 🐛 Bug 2 — PubSub subscriber leak on Back/Forward/Reload/Delete Cache/Cookies/Storage

`registerNavigationHandlers` calls `webViewPubSub.subscribe(...)` for `RELOAD`, `BACK`, `FORWARD`, `DELETE_STORAGE`, `DELETE_COOKIES`, `DELETE_CACHE`. It is invoked from a `useEffect` whose dependency list includes `address`, so it runs on every navigation. There is no matching `unsubscribe` in the cleanup, so subscribers accumulate without bound.

After N navigations, a single Back/Forward/Reload click fires N copies of the handler. `goBack()` / `goForward()` then jump multiple history entries (or queue rapidly), and Delete Cookies/Cache/Storage make redundant IPC calls.

**Fix:** Have `registerNavigationHandlers` return an unsubscribe function that removes every handler it subscribed. The big effect now stores that fn and invokes it from cleanup alongside the existing webview-event removers.

---

### 🎯 Result

- Typing a new URL navigates reliably on Electron 40+, including on a secondary preview that previously only saw `src` updates.
- Back / Forward each step exactly one history entry, regardless of how long the session has been running.
- Delete Cookies/Cache/Storage trigger a single IPC call per click instead of one per accumulated subscription.

### 🖼️ Testing

- Loaded multiple sites (google.com, github.com, an internal site that 302-redirects unauthenticated users) and verified the address bar reflects what the user typed and the webview navigates accordingly.
- Pressed Back/Forward repeatedly across a navigation history of 10+ entries — each click moves exactly one step.
- Delete Cookies/Cache/Storage invoked once, observed a single IPC call in the main process logs.
- `yarn typecheck` passes.

### 🔍 Files changed

- `desktop-app/src/renderer/components/Previewer/Device/index.tsx` only.
