### PR TITLE
fix: resolve window focus and build issues on Windows

### DIFF
--- a/desktop-app/.erb/scripts/delete-source-maps.js
+++ b/desktop-app/.erb/scripts/delete-source-maps.js
@@ -3,6 +3,6 @@ import rimraf from 'rimraf';
 import webpackPaths from '../configs/webpack.paths';
 
 export default function deleteSourceMaps() {
-  rimraf.sync(path.join(webpackPaths.distMainPath, '*.js.map'));
-  rimraf.sync(path.join(webpackPaths.distRendererPath, '*.js.map'));
+  rimraf.sync(path.join(webpackPaths.distMainPath, '*.js.map'), {glob: true});
+  rimraf.sync(path.join(webpackPaths.distRendererPath, '*.js.map'), {glob: true});
 }

--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -49,6 +49,33 @@ let urlToOpen: string | undefined = cli.input[0]?.includes('electronmon')
 
 let mainWindow: BrowserWindow | null = null;
 
+const bringWindowToFront = (window: BrowserWindow) => {
+  if (window.isDestroyed()) {
+    return;
+  }
+
+  if (window.isMinimized()) {
+    window.restore();
+  }
+
+  window.show();
+  window.moveTop();
+  window.focus();
+  window.flashFrame(false);
+};
+
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+
+if (!gotSingleInstanceLock) {
+  app.quit();
+}
+
+app.on('second-instance', () => {
+  if (mainWindow) {
+    bringWindowToFront(mainWindow);
+  }
+});
+
 initAppMetaHandlers();
 initWebviewContextMenu();
 initScreenshotHandlers();
@@ -158,30 +185,6 @@ const createWindow = async () => {
     `${resolveHtmlPath('index.html')}?urlToOpen=${encodeURI(urlToOpen ?? 'undefined')}`
   );
 
-  const isWindows = process.platform === 'win32';
-  let needsFocusFix = false;
-  let triggeringProgrammaticBlur = false;
-
-  mainWindow.on('blur', () => {
-    if (!triggeringProgrammaticBlur) {
-      needsFocusFix = true;
-    }
-  });
-
-  mainWindow.on('focus', () => {
-    if (isWindows && needsFocusFix) {
-      needsFocusFix = false;
-      triggeringProgrammaticBlur = true;
-      setTimeout(function () {
-        mainWindow!.blur();
-        mainWindow!.focus();
-        setTimeout(function () {
-          triggeringProgrammaticBlur = false;
-        }, 100);
-      }, 100);
-    }
-  });
-
   mainWindow.on('ready-to-show', async () => {
     if (!isAppInitiated) {
       await initInstance();
@@ -199,12 +202,11 @@ const createWindow = async () => {
         mainWindow.showInactive();
         windowShownOnOpen = true;
       } else {
-        mainWindow.showInactive();
         if (!windowShownOnOpen) {
           windowShownOnOpen = true;
-          mainWindow.show();
+          bringWindowToFront(mainWindow);
         } else {
-          mainWindow.showInactive();
+          bringWindowToFront(mainWindow);
         }
       }
     }
@@ -263,6 +265,7 @@ app.on('open-url', async (event, url) => {
   }
   windowShownOnOpen = false;
   openUrl(actualURL, mainWindow);
+  bringWindowToFront(mainWindow);
 });
 
 /**
@@ -294,6 +297,7 @@ app
       // On macOS it's common to re-create a window in the app when the
       // dock icon is clicked and there are no other windows open.
       if (mainWindow === null) createWindow();
+      else bringWindowToFront(mainWindow);
     });
   })
   .catch(console.log);

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
@@ -10,10 +10,10 @@ interface Props {
 export const SettingsContent = ({onClose}: Props) => {
   const id = useId();
   const [screenshotSaveLocation, setScreenshotSaveLocation] = useState<string>(
-    window.electron.store.get('userPreferences.screenshot.saveLocation')
+    window.electron.store.get('userPreferences.screenshot.saveLocation') ?? ''
   );
   const [webRequestHeaderAcceptLanguage, setWebRequestHeaderAcceptLanguage] = useState<string>(
-    window.electron.store.get('userPreferences.webRequestHeaderAcceptLanguage')
+    window.electron.store.get('userPreferences.webRequestHeaderAcceptLanguage') ?? ''
   );
 
   const onSave = () => {


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

N/A

### ℹ️ About the PR

This PR fixes a Windows focus issue where Responsively could flash in the taskbar and require a second click before the existing app window was brought to the foreground.

The previous Windows focus workaround listened for focus/blur events and programmatically called `blur()` followed by `focus()`. In practice, that could cancel the first foreground attempt and leave the app flashing instead of opening immediately.

This PR replaces that behavior with a simpler and more predictable window activation flow:

- Restores the window if minimized
- Shows the window
- Moves it to the top of the z-order
- Focuses it
- Stops taskbar flashing

It also keeps the single-instance behavior so launching Responsively again brings the existing window forward instead of opening another instance.

Additionally, this PR fixes the Windows production build by enabling glob handling in the source-map cleanup script used before packaging.

### 🖼️ Testing Scenarios / Screenshots

Tested on Windows by generating and installing a packaged `.exe`.

Validation performed:

- `corepack yarn run typecheck`
- `corepack yarn test`
- `corepack yarn package --config.win.signAndEditExecutable=false`

Manual scenarios tested:

- Open Responsively, place another app such as Chrome or VS Code above it, then click Responsively once from the taskbar.
- Confirm Responsively comes to the foreground on the first click.
- Confirm it no longer flashes orange in the taskbar waiting for a second click.
- Confirm switching back to Chrome/VS Code still works normally.
- Launch Responsively again while it is already running and confirm the existing window is brought forward.