### PR TITLE
Fix individual device rotation button

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -20,7 +20,6 @@ interface Props {
   onRotate: (state: boolean) => void;
   onIndividualLayoutHandler: (device: Device) => void;
   isIndividualLayout: boolean;
-  isDeviceRotationEnabled: boolean;
 }
 
 const Toolbar = ({
@@ -32,7 +31,6 @@ const Toolbar = ({
   onRotate,
   onIndividualLayoutHandler,
   isIndividualLayout,
-  isDeviceRotationEnabled,
 }: Props) => {
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, {volume: 0.5});
@@ -177,9 +175,9 @@ const Toolbar = ({
         </Button>
         <Button
           onClick={rotate}
-          disabled={!isDeviceRotationEnabled}
+          disabled={!device.isMobileCapable}
           title={
-            isDeviceRotationEnabled
+            device.isMobileCapable
               ? 'Rotate This Device'
               : 'Rotation not available for non-mobile devices'
           }

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -564,7 +564,6 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
         onRotate={onRotateHandler}
         onIndividualLayoutHandler={onIndividualLayoutHandler}
         isIndividualLayout={isIndividualLayout}
-        isDeviceRotationEnabled={isDeviceRotationEnabled}
       />
       <div className="flex gap-4">
         <div


### PR DESCRIPTION
## Summary
- enables the per-device rotate button for mobile-capable devices even before they are rotated
- keeps non-mobile devices disabled
- removes the redundant toolbar prop that used the current rotated state as the availability check

Fixes #1492.

## Testing
- Ran git diff --check
- Not run locally: project dependencies are not installed in this checkout