### PR TITLE
Fix individual device rotation

### DIFF
--- a/desktop-app/e2e/tests/rotate-devices.spec.ts
+++ b/desktop-app/e2e/tests/rotate-devices.spec.ts
@@ -53,22 +53,34 @@ test.describe('Rotate Devices', () => {
   test('per-device rotate button in device toolbar works independently', async ({app}) => {
     await app.dismissModals();
 
-    // Per-device rotate buttons — some may be disabled for non-mobile devices
     const perDeviceRotateBtn = app.page.locator('button[title="Rotate This Device"]').first();
+    await expect(perDeviceRotateBtn).toBeVisible();
+    await expect(perDeviceRotateBtn).toBeEnabled();
 
-    const isVisible = await perDeviceRotateBtn.isVisible().catch(() => false);
+    const dimensionsBefore = await app.firstWebview.evaluate((node) => {
+      const {height, width} = (node as HTMLElement).style;
+      return {height, width};
+    });
 
-    if (isVisible) {
-      await perDeviceRotateBtn.click();
-      await app.page.waitForTimeout(500);
+    await perDeviceRotateBtn.click();
+    await app.page.waitForTimeout(500);
 
-      const styleAfter = await app.firstWebview.getAttribute('style');
-      // Style should have changed for a mobile-capable device
-      expect(styleAfter).toBeTruthy();
+    const dimensionsAfter = await app.firstWebview.evaluate((node) => {
+      const {height, width} = (node as HTMLElement).style;
+      return {height, width};
+    });
 
-      // Click again to revert
-      await perDeviceRotateBtn.click();
-      await app.page.waitForTimeout(300);
-    }
+    expect(dimensionsAfter.width).toBe(dimensionsBefore.height);
+    expect(dimensionsAfter.height).toBe(dimensionsBefore.width);
+
+    await perDeviceRotateBtn.click();
+    await app.page.waitForTimeout(300);
+
+    const dimensionsRestored = await app.firstWebview.evaluate((node) => {
+      const {height, width} = (node as HTMLElement).style;
+      return {height, width};
+    });
+
+    expect(dimensionsRestored).toEqual(dimensionsBefore);
   });
 });

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -20,7 +20,7 @@ interface Props {
   onRotate: (state: boolean) => void;
   onIndividualLayoutHandler: (device: Device) => void;
   isIndividualLayout: boolean;
-  isDeviceRotationEnabled: boolean;
+  canRotateDevice: boolean;
 }
 
 const Toolbar = ({
@@ -32,7 +32,7 @@ const Toolbar = ({
   onRotate,
   onIndividualLayoutHandler,
   isIndividualLayout,
-  isDeviceRotationEnabled,
+  canRotateDevice,
 }: Props) => {
   const [eventMirroringOff, setEventMirroringOff] = useState<boolean>(false);
   const [playScreenshotDone] = useSound(screenshotSfx, {volume: 0.5});
@@ -177,11 +177,10 @@ const Toolbar = ({
         </Button>
         <Button
           onClick={rotate}
-          disabled={!isDeviceRotationEnabled}
+          disabled={!canRotateDevice}
+          isActive={rotated}
           title={
-            isDeviceRotationEnabled
-              ? 'Rotate This Device'
-              : 'Rotation not available for non-mobile devices'
+            canRotateDevice ? 'Rotate This Device' : 'Rotation not available for non-mobile devices'
           }
         >
           <Icon icon={rotated ? 'mdi:phone-rotate-portrait' : 'mdi:phone-rotate-landscape'} />

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -119,11 +119,12 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
   let {height, width} = device;
 
-  // Check if device rotation is enabled (only mobile-capable devices can be rotated)
-  const isDeviceRotationEnabled = device.isMobileCapable && (rotateDevices || singleRotated);
+  // Only mobile-capable devices can rotate; rotation state decides when to swap dimensions.
+  const canRotateDevice = device.isMobileCapable;
+  const isDeviceRotated = canRotateDevice && (rotateDevices || singleRotated);
 
   // Apply rotation: both global and individual rotation only affect mobile-capable devices
-  if (isDeviceRotationEnabled) {
+  if (isDeviceRotated) {
     const temp = width;
     width = height;
     height = temp;
@@ -537,8 +538,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const scaledHeight = height * zoomfactor;
   const scaledWidth = width * zoomfactor;
 
-  const isRestrictedMinimumDeviceSize =
-    device.width < 400 && zoomfactor < 0.6 && !isDeviceRotationEnabled;
+  const isRestrictedMinimumDeviceSize = device.width < 400 && zoomfactor < 0.6 && !isDeviceRotated;
 
   return (
     <div
@@ -564,7 +564,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
         onRotate={onRotateHandler}
         onIndividualLayoutHandler={onIndividualLayoutHandler}
         isIndividualLayout={isIndividualLayout}
-        isDeviceRotationEnabled={isDeviceRotationEnabled}
+        canRotateDevice={canRotateDevice}
       />
       <div className="flex gap-4">
         <div


### PR DESCRIPTION
Fixes #1492

## Summary
This PR fixes the individual device rotation control in Responsively App.

The original issue was that the per-device rotate button could be disabled before it was ever usable. The previous logic used the current rotation state to decide whether the button should be enabled. Since an individual device starts unrotated, the button could be disabled on first render, preventing users from rotating a single device.

## Changes
- Separate whether a device can rotate from whether a device is currently rotated.
- Enable the per-device rotate button for mobile-capable devices.
- Keep width/height swapping controlled by the actual rotation state.
- Update the e2e test to verify the per-device rotate button is enabled and swaps dimensions.

## Verification
- npm run typecheck
- npx eslint src/renderer/components/Previewer/Device/Toolbar.tsx src/renderer/components/Previewer/Device/index.tsx e2e/tests/rotate-devices.spec.ts --ext .ts,.tsx --quiet
