### PR TITLE
feat: add dynamic resize handles for custom devices

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -182,6 +182,39 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     );
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const step = e.shiftKey ? 10 : 1;
+      const change = e.key === 'ArrowRight' ? step : -step;
+      const currentVal = isDeviceRotationEnabled
+        ? (localHeight !== null ? localHeight : device.height)
+        : (localWidth !== null ? localWidth : device.width);
+      const newVal = Math.max(200, currentVal + change);
+
+      if (isDeviceRotationEnabled) {
+        setLocalHeight(newVal);
+      } else {
+        setLocalWidth(newVal);
+      }
+
+      const finalWidth = isDeviceRotationEnabled
+        ? (localWidth !== null ? localWidth : device.width)
+        : newVal;
+      const finalHeight = isDeviceRotationEnabled
+        ? newVal
+        : (localHeight !== null ? localHeight : device.height);
+
+      dispatch(
+        updateCustomDeviceDimensions({
+          id: device.id,
+          width: finalWidth,
+          height: finalHeight,
+        })
+      );
+    }
+  };
+
   const resolution: ViewResolution = `${width}x${height}`;
   const designOverlay = useSelector((state: RootState) => selectDesignOverlay(state)(resolution));
 
@@ -705,23 +738,29 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
           {device.isCustom && (
             <div
-              className="absolute right-0 top-0 bottom-0 w-[10px] cursor-col-resize z-50 group flex items-center justify-center select-none"
+              className="absolute right-0 top-0 bottom-0 w-[10px] cursor-col-resize z-50 group flex items-center justify-center select-none focus:outline-none focus:bg-emerald-500/10 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
               onMouseDown={handleMouseDown}
+              onKeyDown={handleKeyDown}
+              role="separator"
+              tabIndex={0}
+              aria-label={`Resize ${device.name}`}
+              aria-valuenow={width}
+              aria-valuemin={200}
             >
               {/* Highlight bar */}
               <div
                 className={cx(
                   'w-[4px] h-full transition-colors duration-150',
-                  isDragging ? 'bg-emerald-500' : 'bg-transparent group-hover:bg-emerald-500/30'
+                  isDragging ? 'bg-emerald-500' : 'bg-transparent group-hover:bg-emerald-500/30 group-focus:bg-emerald-500/30'
                 )}
               />
               {/* Gripper capsule */}
               <div
                 className={cx(
-                  'absolute w-[6px] h-10 rounded-full border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 flex flex-col items-center justify-center gap-[2px] shadow-sm transition-all duration-150 group-hover:scale-y-110',
+                  'absolute w-[6px] h-10 rounded-full border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 flex flex-col items-center justify-center gap-[2px] shadow-sm transition-all duration-150 group-hover:scale-y-110 group-focus:scale-y-110',
                   isDragging
-                    ? 'border-emerald-500 bg-emerald-50 dark:bg-slate-900'
-                    : 'opacity-0 group-hover:opacity-100'
+                    ? 'border-emerald-500 bg-emerald-50 dark:bg-slate-900 opacity-100'
+                    : 'opacity-0 group-hover:opacity-100 group-focus:opacity-100'
                 )}
               >
                 <div className="w-[2px] h-[2px] rounded-full bg-slate-400 dark:bg-slate-500" />

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -93,8 +93,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const [localWidth, setLocalWidth] = useState<number | null>(null);
   const [localHeight, setLocalHeight] = useState<number | null>(null);
   const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [dragStartWidth, setDragStartWidth] = useState<number>(0);
-  const [dragStartHeight, setDragStartHeight] = useState<number>(0);
+  const [dragStartVisualWidth, setDragStartVisualWidth] = useState<number>(0);
   const [dragStartX, setDragStartX] = useState<number>(0);
 
   useEffect(() => {
@@ -154,20 +153,18 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     e.preventDefault();
     setIsDragging(true);
     setDragStartX(e.clientX);
-    setDragStartWidth(device.isCustom && localWidth !== null ? localWidth : device.width);
-    setDragStartHeight(device.isCustom && localHeight !== null ? localHeight : device.height);
+    setDragStartVisualWidth(width);
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!isDragging) return;
     const deltaX = e.clientX - dragStartX;
     const change = Math.round(deltaX / zoomfactor);
+    const newVisualWidth = Math.max(200, dragStartVisualWidth + change);
     if (isDeviceRotationEnabled) {
-      const newHeight = Math.max(200, dragStartHeight + change);
-      setLocalHeight(newHeight);
+      setLocalHeight(newVisualWidth);
     } else {
-      const newWidth = Math.max(200, dragStartWidth + change);
-      setLocalWidth(newWidth);
+      setLocalWidth(newVisualWidth);
     }
   };
 

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -188,8 +188,12 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       const step = e.shiftKey ? 10 : 1;
       const change = e.key === 'ArrowRight' ? step : -step;
       const currentVal = isDeviceRotationEnabled
-        ? (localHeight !== null ? localHeight : device.height)
-        : (localWidth !== null ? localWidth : device.width);
+        ? localHeight !== null
+          ? localHeight
+          : device.height
+        : localWidth !== null
+          ? localWidth
+          : device.width;
       const newVal = Math.max(200, currentVal + change);
 
       if (isDeviceRotationEnabled) {
@@ -199,11 +203,15 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       }
 
       const finalWidth = isDeviceRotationEnabled
-        ? (localWidth !== null ? localWidth : device.width)
+        ? localWidth !== null
+          ? localWidth
+          : device.width
         : newVal;
       const finalHeight = isDeviceRotationEnabled
         ? newVal
-        : (localHeight !== null ? localHeight : device.height);
+        : localHeight !== null
+          ? localHeight
+          : device.height;
 
       dispatch(
         updateCustomDeviceDimensions({
@@ -741,17 +749,20 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
               className="absolute right-0 top-0 bottom-0 w-[10px] cursor-col-resize z-50 group flex items-center justify-center select-none focus:outline-none focus:bg-emerald-500/10 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
               onMouseDown={handleMouseDown}
               onKeyDown={handleKeyDown}
-              role="separator"
+              role="slider"
               tabIndex={0}
               aria-label={`Resize ${device.name}`}
               aria-valuenow={width}
               aria-valuemin={200}
+              aria-valuemax={3000}
             >
               {/* Highlight bar */}
               <div
                 className={cx(
                   'w-[4px] h-full transition-colors duration-150',
-                  isDragging ? 'bg-emerald-500' : 'bg-transparent group-hover:bg-emerald-500/30 group-focus:bg-emerald-500/30'
+                  isDragging
+                    ? 'bg-emerald-500'
+                    : 'bg-transparent group-hover:bg-emerald-500/30 group-focus:bg-emerald-500/30'
                 )}
               />
               {/* Gripper capsule */}
@@ -778,6 +789,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
           )}
 
           {isDragging && (
+            /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
             <div
               className="fixed inset-0 z-[9999] cursor-col-resize bg-transparent"
               onMouseMove={handleMouseMove}

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -48,6 +48,7 @@ import {
   setRuler,
 } from '../../../store/features/ruler';
 import {selectDarkMode} from '../../../store/features/ui';
+import {updateCustomDeviceDimensions} from 'renderer/store/features/device-manager';
 import useKeyboardShortcut, {
   SHORTCUT_CHANNEL,
 } from '../../KeyboardShortcutsManager/useKeyboardShortcut';
@@ -89,6 +90,18 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const isNavigatingFromAddressBar = useRef<boolean>(false);
   const [webviewReady, setWebviewReady] = useState<boolean>(false);
 
+  const [localWidth, setLocalWidth] = useState<number | null>(null);
+  const [localHeight, setLocalHeight] = useState<number | null>(null);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [dragStartWidth, setDragStartWidth] = useState<number>(0);
+  const [dragStartHeight, setDragStartHeight] = useState<number>(0);
+  const [dragStartX, setDragStartX] = useState<number>(0);
+
+  useEffect(() => {
+    setLocalWidth(null);
+    setLocalHeight(null);
+  }, [device.width, device.height, device.id]);
+
   useEffect(() => {
     if (ref.current && isPrimary) {
       try {
@@ -118,6 +131,14 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
 
   let {height, width} = device;
+  if (device.isCustom) {
+    if (localWidth !== null) {
+      width = localWidth;
+    }
+    if (localHeight !== null) {
+      height = localHeight;
+    }
+  }
 
   // Check if device rotation is enabled (only mobile-capable devices can be rotated)
   const isDeviceRotationEnabled = device.isMobileCapable && (rotateDevices || singleRotated);
@@ -128,6 +149,41 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     width = height;
     height = temp;
   }
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    setDragStartX(e.clientX);
+    setDragStartWidth(device.isCustom && localWidth !== null ? localWidth : device.width);
+    setDragStartHeight(device.isCustom && localHeight !== null ? localHeight : device.height);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    const deltaX = e.clientX - dragStartX;
+    const change = Math.round(deltaX / zoomfactor);
+    if (isDeviceRotationEnabled) {
+      const newHeight = Math.max(200, dragStartHeight + change);
+      setLocalHeight(newHeight);
+    } else {
+      const newWidth = Math.max(200, dragStartWidth + change);
+      setLocalWidth(newWidth);
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    const finalWidth = localWidth !== null ? localWidth : device.width;
+    const finalHeight = localHeight !== null ? localHeight : device.height;
+    dispatch(
+      updateCustomDeviceDimensions({
+        id: device.id,
+        width: finalWidth,
+        height: finalHeight,
+      })
+    );
+  };
 
   const resolution: ViewResolution = `${width}x${height}`;
   const designOverlay = useSelector((state: RootState) => selectDesignOverlay(state)(resolution));
@@ -649,6 +705,49 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
               </div>
             </div>
           ) : null}
+
+          {device.isCustom && (
+            <div
+              className="absolute right-0 top-0 bottom-0 w-[10px] cursor-col-resize z-50 group flex items-center justify-center select-none"
+              onMouseDown={handleMouseDown}
+            >
+              {/* Highlight bar */}
+              <div
+                className={cx(
+                  'w-[4px] h-full transition-colors duration-150',
+                  isDragging ? 'bg-emerald-500' : 'bg-transparent group-hover:bg-emerald-500/30'
+                )}
+              />
+              {/* Gripper capsule */}
+              <div
+                className={cx(
+                  'absolute w-[6px] h-10 rounded-full border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 flex flex-col items-center justify-center gap-[2px] shadow-sm transition-all duration-150 group-hover:scale-y-110',
+                  isDragging
+                    ? 'border-emerald-500 bg-emerald-50 dark:bg-slate-900'
+                    : 'opacity-0 group-hover:opacity-100'
+                )}
+              >
+                <div className="w-[2px] h-[2px] rounded-full bg-slate-400 dark:bg-slate-500" />
+                <div className="w-[2px] h-[2px] rounded-full bg-slate-400 dark:bg-slate-500" />
+                <div className="w-[2px] h-[2px] rounded-full bg-slate-400 dark:bg-slate-500" />
+              </div>
+
+              {/* Tooltip */}
+              {isDragging && (
+                <div className="absolute right-4 top-1/2 -translate-y-1/2 bg-slate-950/90 dark:bg-white/95 text-white dark:text-slate-950 text-xs font-semibold px-2.5 py-1 rounded-md shadow-xl border border-slate-800 dark:border-slate-200 pointer-events-none whitespace-nowrap z-50">
+                  {width}px
+                </div>
+              )}
+            </div>
+          )}
+
+          {isDragging && (
+            <div
+              className="fixed inset-0 z-[9999] cursor-col-resize bg-transparent"
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+            />
+          )}
         </div>
 
         {designOverlay?.enabled && designOverlay.image && designOverlay.position === 'side' && (

--- a/desktop-app/src/renderer/store/features/device-manager/index.ts
+++ b/desktop-app/src/renderer/store/features/device-manager/index.ts
@@ -100,6 +100,35 @@ export const deviceManagerSlice = createSlice({
       window.electron.store.set('deviceManager.previewSuites', [defaultSuites]);
       state.suites = [defaultSuites];
     },
+    updateCustomDeviceDimensions(
+      state,
+      action: PayloadAction<{id: string; width: number; height: number}>
+    ) {
+      const {id, width, height} = action.payload;
+      const customDevicesList: Device[] =
+        window.electron.store.get('deviceManager.customDevices') || [];
+      const updatedCustomDevices = customDevicesList.map((d) => {
+        if (d.id === id) {
+          return {...d, width, height};
+        }
+        return d;
+      });
+      window.electron.store.set('deviceManager.customDevices', updatedCustomDevices);
+
+      if (state.devices) {
+        state.devices = state.devices.map((d) => {
+          if (d.id === id) {
+            return {...d, width, height};
+          }
+          return d;
+        });
+      }
+
+      state.suites = state.suites.map((suite) => ({
+        ...suite,
+        devices: [...suite.devices],
+      }));
+    },
   },
 });
 
@@ -112,6 +141,7 @@ export const {
   addSuites,
   deleteSuite,
   deleteAllSuites,
+  updateCustomDeviceDimensions,
 } = deviceManagerSlice.actions;
 
 export const selectSuites = (state: RootState) => state.deviceManager.suites;


### PR DESCRIPTION
# ✨ Pull Request

### 📓 Referenced Issue

Resolves: #1491

### ℹ️ About the PR

This PR introduces interactive, on-the-fly resizing for custom device preview frames. It allows developers to resize custom devices directly from the preview screen without having to navigate back and forth to the device manager settings.

**Key Features & Implementation Details:**
1. **Dynamic Resize Handle**:
   - Added an interactive grab target on the right edge of all custom devices (`device.isCustom === true`).
   - The handle is transparent by default to maintain a clean preview workspace, showing a subtle green hover bar and a central gripper capsule on hover/active dragging.
2. **State Sync & Persistence**:
   - Created a new Redux action `updateCustomDeviceDimensions` that updates the custom device parameters inside `electron-store` for long-term persistence.
   - Shallow-copies active suite references in Redux to force clean layout updates upon release of the handle.
3. **Live Unzoomed Width Tooltip**:
   - Renders a floating tooltip indicating the exact unzoomed device width (e.g. `420px`) during the resize action.
4. **Event Interception Overlay**:
   - Rendered a temporary transparent full-screen overlay during active resizing. This prevents Electron's guest `<webview>` elements from capturing and blocking pointer/drag events, ensuring a smooth and uninterrupted resize feel.
5. **Rotation Compatibility**:
   - Smart visual resizing mapping: correctly updates the original height (instead of width) when the device is in a rotated landscape state.

### 🖼️ Testing Scenarios / Screenshots

- **Visual Resizing**: Dragged custom devices to various dimensions, verifying that the layout inside the webview resizes dynamically in real-time.
- **Tooltip**: Verified that the live tooltip reflects the current width.
- **Rotation**: Rotated a custom device and verified that dragging the right edge correctly resizes the landscape width (original portrait height).
- **Persistence**: Checked that custom device dimensions remain saved after switching suites and restarting the application.
