### PR TITLE
fix: prevent last device cutoff in Flex preview layout

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -76,7 +76,7 @@ const Previewer = () => {
               </TypedMasonry>
             ) : (
               <div
-                className={cx('flex h-full gap-4 overflow-auto p-4', {
+                className={cx('flex min-h-full gap-4 overflow-auto p-4', {
                   'flex-wrap': layout === PREVIEW_LAYOUTS.FLEX,
                   'justify-center': isIndividualLayout,
                 })}


### PR DESCRIPTION
## Problem

In Flex preview layout, when devices wrap to multiple rows, the last device view at the bottom is clipped — its footer is cut off and not scrollable.

**Root cause:** The inner layout container at `Previewer/index.tsx:79` used `h-full`, which constrained the flex container to the exact height of the parent viewport. When wrapped devices exceeded this height, `overflow-auto` created a nested scroll container instead of letting the parent `overflow-y-auto` container handle scrolling properly.

## Fix

Changed `h-full` → `min-h-full` on the inner layout container.

- **Before:** Container is locked to viewport height; wrapped devices overflow into a nested scroll area that clips the last device.
- **After:** Container grows to fit all wrapped devices; the parent scroll container (`overflow-y-auto` on line 64) provides smooth scrolling to access the last device.

This change is safe for all layout modes:
- **Column:** Devices in a horizontal row — container stays at viewport height (content is shorter).
- **Flex:** Devices wrap — container grows as needed, parent scrolls.
- **Individual:** Single device — no behavioral change.

## Testing

1. Open Responsively App
2. Add multiple devices (enough to cause wrapping in Flex layout)
3. Switch to Flex layout
4. Scroll down — last device should be fully visible with footer intact

Fixes #1022