### PR TITLE
fix: preserve window bounds on reload to prevent resize on Windows

### DIFF
--- a/desktop-app/src/main/menu/view.ts
+++ b/desktop-app/src/main/menu/view.ts
@@ -24,7 +24,11 @@ const getReloadMenu = (mainWindow: BrowserWindow): MenuItemConstructorOptions =>
   accelerator: 'CommandOrControl+R',
   click: () => {
     if (isDev) {
+      const bounds = mainWindow.getBounds();
       mainWindow.webContents.reload();
+      mainWindow.webContents.once('did-finish-load', () => {
+        mainWindow.setBounds(bounds);
+      });
       return;
     }
     mainWindow.webContents.send('reload', {});


### PR DESCRIPTION
## Description

When the app window is snapped to half screen using Windows Snap and Ctrl+R is pressed (or View → Reload is used), the Electron window loses its snapped position and resizes to full width. This is caused by a known [Electron bug (#25359)](https://github.com/electron/electron/issues/25359).

## Fix

Save the window bounds (position and size) before calling `webContents.reload()`, then restore them when the page finishes loading via the `did-finish-load` event.

## Changes

- `desktop-app/src/main/menu/view.ts`: In the dev-mode reload handler, save `mainWindow.getBounds()` before reload and restore them via `mainWindow.setBounds()` after `did-finish-load` fires.

## Testing

- Build passes: `yarn build`
- All tests pass: `yarn test` (69 tests, 14 files)

## Notes

- This fix applies to the dev-mode reload path (`webContents.reload()`). In production mode, the reload sends an IPC message to reload individual webview tags, which does not reload the BrowserWindow and should not trigger this issue.
- The fix only runs when `isDev` is true, so it has no impact on production behavior.

Fixes #999