### PR TITLE
fix(ci): switch test runner to macos-13 and add Electron diagnostics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-13]
       fail-fast: false
 
     steps:
@@ -40,6 +40,20 @@ jobs:
           yarn run lint
           yarn exec tsc
           yarn test
+
+      - name: Verify Electron installation
+        if: always()
+        run: |
+          echo "=== path.txt ==="
+          cat node_modules/electron/path.txt 2>&1 || echo "MISSING"
+          echo "=== dist/version ==="
+          cat node_modules/electron/dist/version 2>&1 || echo "MISSING"
+          echo "=== Binary file ==="
+          file node_modules/electron/dist/Electron.app/Contents/MacOS/Electron 2>&1 || echo "MISSING"
+          echo "=== dist/ contents ==="
+          ls -la node_modules/electron/dist/ 2>&1 || echo "EMPTY"
+          echo "=== node -e require('electron') ==="
+          node -e "console.log(require('electron'))" 2>&1 || echo "FAILED"
 
       - name: E2E Tests
         run: yarn test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-latest-large]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest-large]
+        os: [macos-13]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The Test workflow consistently fails on macos-latest (arm64) because the Electron binary is not properly installed — 'path.txt' or the binary at 'dist/Electron.app/Contents/MacOS/Electron' is missing after yarn install.

This is likely caused by:
1. Yarn cache architecture mismatch between x64 and arm64 runners
2. Electron postinstall not re-executing when restoring from cache
3. @electron/get download failures on arm64 GitHub Actions runners

Changes:
- Switch runner from macos-latest (arm64/macOS 26) to macos-13 (Intel) to match the publish.yml workflow which already uses macos-13
- Add a diagnostic step before E2E tests to verify Electron installation (checks path.txt, dist/version, binary file, and require('electron'))

Fixes #1512