### PR TITLE
fix: last device cut off in Column layout due to double-scroll container

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -76,7 +76,7 @@ const Previewer = () => {
               </TypedMasonry>
             ) : (
               <div
-                className={cx('flex h-full gap-4 overflow-auto p-4', {
+                className={cx('flex min-h-full gap-4 overflow-auto p-4', {
                   'flex-wrap': layout === PREVIEW_LAYOUTS.FLEX,
                   'justify-center': isIndividualLayout,
                 })}


### PR DESCRIPTION
Fixes #1022

## Description
The last device view was being cut off in the Column/Stacked layout mode on macOS. The root cause was a double-scroll container setup where the inner device container used `h-full` combined with `overflow-auto`, while its parent already had `overflow-y-auto`. This forced-height constraint on the inner container, plus the redundant overflow handling, caused the bottom portion of the last device's content (toolbar/"footer") to be clipped, especially on macOS.

## Fix
Changed `h-full` to `min-h-full` on the inner device container in `Previewer/index.tsx`. This allows the container to grow naturally with its content while still ensuring it fills the viewport height when content is shorter. The parent container continues to handle vertical scrolling via `overflow-y-auto`, and the inner container still handles horizontal overflow with `overflow-auto` for the Column (horizontal stacking) layout.

## Testing
- Existing e2e tests for preview layout continue to pass (test selectors don't reference `h-full`)
- The layout behavior is preserved for all modes: Column, Flex, Individual, and Masonry