### PR TITLE
fix(previewer): prevent automatic iframe top-level window redirections (#1388)

### DIFF
--- a/desktop-app/src/main/native-functions/index.ts
+++ b/desktop-app/src/main/native-functions/index.ts
@@ -32,9 +32,17 @@ export const initNativeFunctionHandlers = () => {
       _,
       arg: DisableDefaultWindowOpenHandlerArgs
     ): Promise<DisableDefaultWindowOpenHandlerResult> => {
-      webContents.fromId(arg.webContentsId)?.setWindowOpenHandler(() => {
-        return {action: 'deny'};
-      });
+      const contents = webContents.fromId(arg.webContentsId);
+      if (contents) {
+        contents.setWindowOpenHandler(() => {
+          return {action: 'deny'};
+        });
+        contents.on('will-frame-navigate', (event) => {
+          if (!event.isMainFrame) {
+            event.preventDefault();
+          }
+        });
+      }
       return {done: true};
     }
   );

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -413,18 +413,18 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       webview.removeEventListener('did-fail-load', didFailLoadHandler);
     });
 
-    if (!isPrimary) {
-      setTimeout(() => {
-        webview.addEventListener('dom-ready', () => {
-          window.electron.ipcRenderer.invoke<
-            DisableDefaultWindowOpenHandlerArgs,
-            DisableDefaultWindowOpenHandlerResult
-          >('disable-default-window-open-handler', {
-            webContentsId: webview.getWebContentsId(),
-          });
-        });
-      }, 2000);
-    }
+    const onDomReadyWindowOpenHandler = () => {
+      window.electron.ipcRenderer.invoke<
+        DisableDefaultWindowOpenHandlerArgs,
+        DisableDefaultWindowOpenHandlerResult
+      >('disable-default-window-open-handler', {
+        webContentsId: webview.getWebContentsId(),
+      });
+    };
+    webview.addEventListener('dom-ready', onDomReadyWindowOpenHandler);
+    handlerRemovers.push(() => {
+      webview.removeEventListener('dom-ready', onDomReadyWindowOpenHandler);
+    });
 
     registerNavigationHandlers();
 


### PR DESCRIPTION
Fixes #1388

### Summary of Changes:
- Added `will-frame-navigate` event listener on webContents to prevent non-main frame (embedded iframes such as HubSpot modules or Spotify widgets) from executing top-level window redirections.
- Registered `disable-default-window-open-handler` on `dom-ready` for all device webviews with clean teardown listeners.