### PR TITLE
Fix/mobile preview cutoff whitespace

### DIFF
--- a/desktop-app/src/main/native-functions/index.ts
+++ b/desktop-app/src/main/native-functions/index.ts
@@ -32,9 +32,17 @@ export const initNativeFunctionHandlers = () => {
       _,
       arg: DisableDefaultWindowOpenHandlerArgs
     ): Promise<DisableDefaultWindowOpenHandlerResult> => {
-      webContents.fromId(arg.webContentsId)?.setWindowOpenHandler(() => {
-        return {action: 'deny'};
-      });
+      const contents = webContents.fromId(arg.webContentsId);
+      if (contents) {
+        contents.setWindowOpenHandler(() => {
+          return {action: 'deny'};
+        });
+        contents.on('will-frame-navigate', (event) => {
+          if (!event.isMainFrame) {
+            event.preventDefault();
+          }
+        });
+      }
       return {done: true};
     }
   );

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -520,9 +520,15 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     const webview = ref.current;
     webview.addEventListener('dom-ready', () => {
       webview.insertCSS(`
-               ::-webkit-scrollbar {
-              display: none;
-              } `);
+        html, body {
+          scrollbar-width: none;
+        }
+        ::-webkit-scrollbar {
+          width: 0px !important;
+          height: 0px !important;
+          display: none !important;
+        }
+      `);
     });
 
     // eslint-disable-next-line consistent-return
@@ -555,9 +561,12 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
   return (
     <div
-      className={cx('h-fit', {
-        'w-52': isRestrictedMinimumDeviceSize,
-      })}
+      className="h-fit"
+      style={{
+        minWidth: isRestrictedMinimumDeviceSize
+          ? Math.max(scaledWidth, 208)
+          : undefined,
+      }}
     >
       <div className="flex justify-between">
         <span>

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -413,18 +413,18 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       webview.removeEventListener('did-fail-load', didFailLoadHandler);
     });
 
-    if (!isPrimary) {
-      setTimeout(() => {
-        webview.addEventListener('dom-ready', () => {
-          window.electron.ipcRenderer.invoke<
-            DisableDefaultWindowOpenHandlerArgs,
-            DisableDefaultWindowOpenHandlerResult
-          >('disable-default-window-open-handler', {
-            webContentsId: webview.getWebContentsId(),
-          });
-        });
-      }, 2000);
-    }
+    const onDomReadyWindowOpenHandler = () => {
+      window.electron.ipcRenderer.invoke<
+        DisableDefaultWindowOpenHandlerArgs,
+        DisableDefaultWindowOpenHandlerResult
+      >('disable-default-window-open-handler', {
+        webContentsId: webview.getWebContentsId(),
+      });
+    };
+    webview.addEventListener('dom-ready', onDomReadyWindowOpenHandler);
+    handlerRemovers.push(() => {
+      webview.removeEventListener('dom-ready', onDomReadyWindowOpenHandler);
+    });
 
     registerNavigationHandlers();
 

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -514,11 +514,11 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
   useEffect(() => {
     if (!ref.current || !device.isMobileCapable) {
-      return;
+      return undefined;
     }
 
     const webview = ref.current;
-    webview.addEventListener('dom-ready', () => {
+    const injectScrollbarCss = () => {
       webview.insertCSS(`
         html, body {
           scrollbar-width: none;
@@ -529,27 +529,31 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
           display: none !important;
         }
       `);
-    });
+    };
 
-    // eslint-disable-next-line consistent-return
+    webview.addEventListener('dom-ready', injectScrollbarCss);
+
     return () => {
-      webview.removeEventListener('dom-ready', () => {});
+      webview.removeEventListener('dom-ready', injectScrollbarCss);
     };
   }, [device.isMobileCapable]);
 
   useEffect(() => {
     const webview = ref.current;
 
-    if (isPrimary && webview) {
-      webview.addEventListener('dom-ready', () => {
-        const pageTitle = webview.getTitle();
-        dispatch(setPageTitle(pageTitle));
-      });
+    if (!isPrimary || !webview) {
+      return undefined;
     }
 
-    // eslint-disable-next-line consistent-return
+    const updateTitle = () => {
+      const pageTitle = webview.getTitle();
+      dispatch(setPageTitle(pageTitle));
+    };
+
+    webview.addEventListener('dom-ready', updateTitle);
+
     return () => {
-      webview?.removeEventListener('dom-ready', () => {});
+      webview.removeEventListener('dom-ready', updateTitle);
     };
   }, [dispatch, isPrimary]);
 

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -567,9 +567,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     <div
       className="h-fit"
       style={{
-        minWidth: isRestrictedMinimumDeviceSize
-          ? Math.max(scaledWidth, 208)
-          : undefined,
+        minWidth: isRestrictedMinimumDeviceSize ? Math.max(scaledWidth, 208) : undefined,
       }}
     >
       <div className="flex justify-between">

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -567,7 +567,9 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     <div
       className="h-fit"
       style={{
-        minWidth: isRestrictedMinimumDeviceSize ? Math.max(scaledWidth, 208) : undefined,
+        minWidth: isRestrictedMinimumDeviceSize
+          ? Math.max(scaledWidth, 208)
+          : undefined,
       }}
     >
       <div className="flex justify-between">


### PR DESCRIPTION
Fixes #1515

### Summary of Changes:
- Replaced rigid fixed `w-52` (208px) container width constraint in `Device/index.tsx` with dynamic `minWidth: Math.max(scaledWidth, 208)` to prevent mobile previews with scaled widths > 208px from being clipped on the right.
- Refined webview injected scrollbar CSS (`scrollbar-width: none; ::-webkit-scrollbar { width: 0 !important; height: 0 !important; }`) to prevent Chromium layout viewport shifts.