### PR TITLE
fix: enable individual device rotation button for all mobile-capable devices

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar.tsx
@@ -63,7 +63,7 @@ const Toolbar = ({
       setEventMirroringOff(!eventMirroringOff);
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('Error while toggleing event mirroring', error);
+      console.error('Error while toggling event mirroring', error);
     }
   };
 

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -132,11 +132,14 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
   let {height, width} = device;
 
-  // Check if device rotation is enabled (only mobile-capable devices can be rotated)
-  const isDeviceRotationEnabled = device.isMobileCapable && (rotateDevices || singleRotated);
+  // Check if this device type supports rotation (all mobile-capable devices)
+  const canRotateDevice = device.isMobileCapable;
+
+  // Check if device is currently rotated (global or individual rotation)
+  const isDeviceRotated = canRotateDevice && (rotateDevices || singleRotated);
 
   // Apply rotation: both global and individual rotation only affect mobile-capable devices
-  if (isDeviceRotationEnabled) {
+  if (isDeviceRotated) {
     const temp = width;
     width = height;
     height = temp;
@@ -551,7 +554,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const scaledWidth = width * zoomfactor;
 
   const isRestrictedMinimumDeviceSize =
-    device.width < 400 && zoomfactor < 0.6 && !isDeviceRotationEnabled;
+    device.width < 400 && zoomfactor < 0.6 && !isDeviceRotated;
 
   return (
     <div
@@ -577,7 +580,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
         onRotate={onRotateHandler}
         onIndividualLayoutHandler={onIndividualLayoutHandler}
         isIndividualLayout={isIndividualLayout}
-        isDeviceRotationEnabled={isDeviceRotationEnabled}
+        isDeviceRotationEnabled={canRotateDevice}
       />
       <div className="flex gap-4">
         <div


### PR DESCRIPTION
## Summary

This PR fixes the individual per-device rotation button that was broken in v1.18.0 (Issue #1492).

### Root Cause

The previous code used a single variable \isDeviceRotationEnabled\ to control **both**:
1. Whether the per-device rotate button was enabled
2. Whether width/height rotation should be applied

This meant the button was only enabled when \otateDevices || singleRotated\ was true. Since \singleRotated\ starts as \alse\, the button was disabled on first render for devices where global rotation was off - making it impossible to rotate a single device.

### Fix

Separate the two concerns into distinct variables:
- \canRotateDevice\ - whether this device type supports rotation (\device.isMobileCapable\). Used to enable/disable the button.
- \isDeviceRotated\ - whether the device is currently rotated (global or individual). Used to apply the width/height swap.

This ensures the per-device rotate button is always enabled for mobile-capable devices, allowing users to rotate individual devices independently.

### Changes

- **\Device/index.tsx\**: Split \isDeviceRotationEnabled\ into \canRotateDevice\ (button enabled state) and \isDeviceRotated\ (rotation applied state)
- **\Toolbar.tsx\**: Fixed typo: 'toggleing' -> 'toggling'

Fixes #1492