### PR TITLE
feat: manage custom HTTP request/response headers

### DIFF
--- a/desktop-app/src/common/headerRules.test.ts
+++ b/desktop-app/src/common/headerRules.test.ts
@@ -1,0 +1,117 @@
+import {
+  ANY,
+  HeaderRule,
+  HeaderRuleAction,
+  HeaderRuleCondition,
+  applyHeaderActions,
+  getMatchingActions,
+  getMatchingRules,
+} from './headerRules';
+
+const condition = (overrides: Partial<HeaderRuleCondition> = {}): HeaderRuleCondition => ({
+  id: 'c1',
+  matchType: 'contains',
+  targetValue: 'preprod.example.com',
+  resourceType: ANY,
+  requestMethod: ANY,
+  enabled: true,
+  ...overrides,
+});
+
+const action = (overrides: Partial<HeaderRuleAction> = {}): HeaderRuleAction => ({
+  id: 'a1',
+  operation: 'set',
+  headerType: 'request',
+  headerName: 'x-control',
+  headerValue: 'secret',
+  enabled: true,
+  ...overrides,
+});
+
+const rule = (overrides: Partial<HeaderRule> = {}): HeaderRule => ({
+  id: 'r1',
+  enabled: true,
+  conditions: [condition()],
+  actions: [action()],
+  ...overrides,
+});
+
+describe('getMatchingRules', () => {
+  it('supports every match type', () => {
+    const url = 'https://preprod.example.com/news';
+    const matches = (overrides: Partial<HeaderRuleCondition>) =>
+      getMatchingRules([rule({conditions: [condition(overrides)]})], {url}).length === 1;
+
+    expect(matches({matchType: 'contains', targetValue: 'PREPROD.example'})).toBe(true);
+    expect(matches({matchType: 'equals', targetValue: url})).toBe(true);
+    expect(matches({matchType: 'equals', targetValue: 'https://preprod.example.com'})).toBe(false);
+    expect(matches({matchType: 'startsWith', targetValue: 'https://preprod'})).toBe(true);
+    expect(matches({matchType: 'endsWith', targetValue: '/news'})).toBe(true);
+    expect(matches({matchType: 'wildcard', targetValue: 'https://*.example.com/*'})).toBe(true);
+    expect(matches({matchType: 'wildcard', targetValue: 'https://*.other.com/*'})).toBe(false);
+    expect(matches({matchType: 'regex', targetValue: '^https://preprod\\..*/news$'})).toBe(true);
+    expect(matches({matchType: 'regex', targetValue: '('})).toBe(false);
+  });
+
+  it('filters on resource type and request method', () => {
+    const request = {url: 'https://preprod.example.com/', method: 'POST', resourceType: 'xhr'};
+
+    expect(getMatchingRules([rule()], request)).toHaveLength(1);
+    expect(
+      getMatchingRules([rule({conditions: [condition({resourceType: 'script'})]})], request)
+    ).toHaveLength(0);
+    expect(
+      getMatchingRules([rule({conditions: [condition({requestMethod: 'GET'})]})], request)
+    ).toHaveLength(0);
+    expect(
+      getMatchingRules([rule({conditions: [condition({requestMethod: 'POST'})]})], request)
+    ).toHaveLength(1);
+  });
+
+  it('requires all enabled conditions to match and skips disabled rules', () => {
+    const request = {url: 'https://preprod.example.com/'};
+    const twoConditions = [condition(), condition({id: 'c2', targetValue: 'staging'})];
+
+    expect(getMatchingRules([rule({conditions: twoConditions})], request)).toHaveLength(0);
+    expect(getMatchingRules([rule({enabled: false})], request)).toHaveLength(0);
+    expect(getMatchingRules([rule({conditions: []})], request)).toHaveLength(0);
+    expect(
+      getMatchingRules([rule({conditions: [condition({targetValue: '  '})]})], request)
+    ).toHaveLength(0);
+  });
+});
+
+describe('getMatchingActions', () => {
+  it('only returns enabled actions of the requested header type', () => {
+    const request = {url: 'https://preprod.example.com/'};
+    const actions = [
+      action(),
+      action({id: 'a2', headerType: 'response'}),
+      action({id: 'a3', enabled: false}),
+      action({id: 'a4', headerName: ' '}),
+    ];
+
+    expect(getMatchingActions([rule({actions})], request, 'request')).toEqual([actions[0]]);
+    expect(getMatchingActions([rule({actions})], request, 'response')).toEqual([actions[1]]);
+  });
+});
+
+describe('applyHeaderActions', () => {
+  it('sets, adds and removes headers case insensitively', () => {
+    expect(applyHeaderActions([action()], {'X-Control': 'old'})).toEqual({'X-Control': 'secret'});
+    expect(applyHeaderActions([action()], {})).toEqual({'x-control': 'secret'});
+    expect(applyHeaderActions([action({operation: 'add'})], {'x-control': 'old'})).toEqual({
+      'x-control': 'old, secret',
+    });
+    expect(applyHeaderActions([action({operation: 'remove'})], {'X-Control': 'old'})).toEqual({});
+  });
+
+  it('keeps response headers as arrays', () => {
+    expect(applyHeaderActions([action()], {} as Record<string, string[]>, true)).toEqual({
+      'x-control': ['secret'],
+    });
+    expect(applyHeaderActions([action({operation: 'add'})], {'x-control': ['old']}, true)).toEqual({
+      'x-control': ['old', 'secret'],
+    });
+  });
+});

--- a/desktop-app/src/common/headerRules.ts
+++ b/desktop-app/src/common/headerRules.ts
@@ -1,0 +1,218 @@
+export const MATCH_TYPES = {
+  CONTAINS: 'contains',
+  EQUALS: 'equals',
+  REGEX: 'regex',
+  WILDCARD: 'wildcard',
+  STARTS_WITH: 'startsWith',
+  ENDS_WITH: 'endsWith',
+} as const;
+
+export type MatchType = (typeof MATCH_TYPES)[keyof typeof MATCH_TYPES];
+
+export const HEADER_OPERATIONS = {
+  SET: 'set',
+  ADD: 'add',
+  REMOVE: 'remove',
+} as const;
+
+export type HeaderOperation = (typeof HEADER_OPERATIONS)[keyof typeof HEADER_OPERATIONS];
+
+export const HEADER_TYPES = {
+  REQUEST: 'request',
+  RESPONSE: 'response',
+} as const;
+
+export type HeaderType = (typeof HEADER_TYPES)[keyof typeof HEADER_TYPES];
+
+/** Matches any resource type or any request method. */
+export const ANY = 'any';
+
+// Electron's webRequest resource types, see details.resourceType
+export const RESOURCE_TYPES = [
+  ANY,
+  'mainFrame',
+  'subFrame',
+  'stylesheet',
+  'script',
+  'image',
+  'font',
+  'object',
+  'xhr',
+  'ping',
+  'cspReport',
+  'media',
+  'webSocket',
+  'other',
+] as const;
+
+export const REQUEST_METHODS = [
+  ANY,
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+
+export interface HeaderRuleCondition {
+  id: string;
+  matchType: MatchType;
+  targetValue: string;
+  resourceType: string;
+  requestMethod: string;
+  enabled: boolean;
+}
+
+export interface HeaderRuleAction {
+  id: string;
+  operation: HeaderOperation;
+  headerType: HeaderType;
+  headerName: string;
+  headerValue: string;
+  enabled: boolean;
+}
+
+export interface HeaderRule {
+  id: string;
+  enabled: boolean;
+  conditions: HeaderRuleCondition[];
+  actions: HeaderRuleAction[];
+}
+
+export interface RequestDetails {
+  url: string;
+  method?: string;
+  resourceType?: string;
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const matchesUrl = (matchType: MatchType, target: string, url: string): boolean => {
+  const lowerCasedUrl = url.toLowerCase();
+  const lowerCasedTarget = target.toLowerCase();
+  switch (matchType) {
+    case MATCH_TYPES.EQUALS:
+      return lowerCasedUrl === lowerCasedTarget;
+    case MATCH_TYPES.STARTS_WITH:
+      return lowerCasedUrl.startsWith(lowerCasedTarget);
+    case MATCH_TYPES.ENDS_WITH:
+      return lowerCasedUrl.endsWith(lowerCasedTarget);
+    case MATCH_TYPES.WILDCARD:
+      return new RegExp(`^${target.split('*').map(escapeRegExp).join('.*')}$`, 'i').test(url);
+    case MATCH_TYPES.REGEX:
+      try {
+        return new RegExp(target, 'i').test(url);
+      } catch {
+        return false;
+      }
+    case MATCH_TYPES.CONTAINS:
+    default:
+      return lowerCasedUrl.includes(lowerCasedTarget);
+  }
+};
+
+const matchesCondition = (condition: HeaderRuleCondition, request: RequestDetails): boolean => {
+  const target = condition.targetValue.trim();
+  if (!condition.enabled || target === '') {
+    return false;
+  }
+  if (
+    condition.resourceType !== ANY &&
+    request.resourceType != null &&
+    condition.resourceType !== request.resourceType
+  ) {
+    return false;
+  }
+  if (
+    condition.requestMethod !== ANY &&
+    request.method != null &&
+    condition.requestMethod.toUpperCase() !== request.method.toUpperCase()
+  ) {
+    return false;
+  }
+  return matchesUrl(condition.matchType, target, request.url);
+};
+
+/** A rule matches when it is enabled and all of its enabled conditions match. */
+export const getMatchingRules = (rules: HeaderRule[], request: RequestDetails): HeaderRule[] => {
+  if (rules == null || request?.url == null) {
+    return [];
+  }
+  return rules.filter((rule) => {
+    if (!rule.enabled) {
+      return false;
+    }
+    const enabledConditions = rule.conditions.filter((condition) => condition.enabled);
+    return (
+      enabledConditions.length > 0 &&
+      enabledConditions.every((condition) => matchesCondition(condition, request))
+    );
+  });
+};
+
+/** Without a headerType, request and response actions are returned together. */
+export const getMatchingActions = (
+  rules: HeaderRule[],
+  request: RequestDetails,
+  headerType?: HeaderType
+): HeaderRuleAction[] =>
+  getMatchingRules(rules, request).flatMap((rule) =>
+    rule.actions.filter(
+      (action) =>
+        action.enabled &&
+        action.headerName.trim() !== '' &&
+        (headerType == null || action.headerType === headerType)
+    )
+  );
+
+/**
+ * Applies the actions to a copy of the given headers, keeping the existing header casing.
+ * Response headers hold arrays of values, request headers hold plain strings.
+ */
+export const applyHeaderActions = <T extends string | string[]>(
+  actions: HeaderRuleAction[],
+  headers: Record<string, T>,
+  multiValue = false
+): Record<string, T> => {
+  const updatedHeaders = {...headers};
+
+  actions.forEach((action) => {
+    const name = action.headerName.trim();
+    const existingKey =
+      Object.keys(updatedHeaders).find((key) => key.toLowerCase() === name.toLowerCase()) ?? name;
+    const existingValue = updatedHeaders[existingKey];
+
+    if (action.operation === HEADER_OPERATIONS.REMOVE) {
+      delete updatedHeaders[existingKey];
+      return;
+    }
+
+    if (action.operation === HEADER_OPERATIONS.ADD && existingValue != null) {
+      updatedHeaders[existingKey] = (
+        Array.isArray(existingValue)
+          ? [...existingValue, action.headerValue]
+          : `${existingValue}, ${action.headerValue}`
+      ) as T;
+      return;
+    }
+
+    updatedHeaders[existingKey] = (multiValue ? [action.headerValue] : action.headerValue) as T;
+  });
+
+  return updatedHeaders;
+};
+
+/** webRequest entry point: picks the matching actions and applies them to the given headers. */
+export const applyRulesToHeaders = <T extends string | string[]>(
+  rules: HeaderRule[],
+  request: RequestDetails,
+  headerType: HeaderType,
+  headers: Record<string, T>
+): Record<string, T> =>
+  applyHeaderActions(
+    getMatchingActions(rules, request, headerType),
+    headers,
+    headerType === HEADER_TYPES.RESPONSE
+  );

--- a/desktop-app/src/main/main.ts
+++ b/desktop-app/src/main/main.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import {app, BrowserWindow, shell, screen, ipcMain} from 'electron';
 import cli from './cli';
 import {PROTOCOL} from '../common/constants';
+import {HEADER_TYPES, HeaderRule, applyRulesToHeaders} from '../common/headerRules';
 import MenuBuilder from './menu';
 import {resolveHtmlPath} from './util';
 import {
@@ -163,7 +164,15 @@ const createWindow = async () => {
 
       details.responseHeaders['content-security-policy'][0] = cspHeader;
     }
-    callback({responseHeaders: details.responseHeaders});
+
+    callback({
+      responseHeaders: applyRulesToHeaders(
+        store.get('headerRules') as HeaderRule[],
+        details,
+        HEADER_TYPES.RESPONSE,
+        details.responseHeaders ?? {}
+      ),
+    });
   });
 
   mainWindow.loadURL(

--- a/desktop-app/src/main/web-permissions/index.ts
+++ b/desktop-app/src/main/web-permissions/index.ts
@@ -1,6 +1,7 @@
 import {BrowserWindow, session, ipcMain} from 'electron';
 import PermissionsManager, {PERMISSION_STATE} from './PermissionsManager';
 import {IPC_MAIN_CHANNELS} from '../../common/constants';
+import {HEADER_TYPES, HeaderRule, applyRulesToHeaders} from '../../common/headerRules';
 import store from '../../store';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -34,7 +35,14 @@ export const WebPermissionHandlers = (mainWindow: BrowserWindow) => {
               'userPreferences.webRequestHeaderAcceptLanguage'
             );
           }
-          callback({requestHeaders: details.requestHeaders});
+          callback({
+            requestHeaders: applyRulesToHeaders(
+              store.get('headerRules') as HeaderRule[],
+              details,
+              HEADER_TYPES.REQUEST,
+              details.requestHeaders
+            ),
+          });
         }
       );
 

--- a/desktop-app/src/renderer/components/ModifyHeadersModal/index.tsx
+++ b/desktop-app/src/renderer/components/ModifyHeadersModal/index.tsx
@@ -1,0 +1,418 @@
+import {Icon} from '@iconify/react';
+import {useEffect, useState} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {v4 as uuidv4} from 'uuid';
+import {
+  ANY,
+  HEADER_OPERATIONS,
+  HEADER_TYPES,
+  HeaderRule,
+  HeaderRuleAction,
+  HeaderRuleCondition,
+  MATCH_TYPES,
+  REQUEST_METHODS,
+  RESOURCE_TYPES,
+} from 'common/headerRules';
+import Button from 'renderer/components/Button';
+import Modal from 'renderer/components/Modal';
+import Toggle from 'renderer/components/Toggle';
+import {webViewPubSub} from 'renderer/lib/pubsub';
+import {
+  selectHeaderRules,
+  selectIsHeaderRulesModalOpen,
+  setHeaderRules,
+  setHeaderRulesModalOpen,
+} from 'renderer/store/features/header-rules';
+import {NAVIGATION_EVENTS} from '../ToolBar/NavigationControls';
+
+const MATCH_TYPE_LABELS: Record<string, string> = {
+  [MATCH_TYPES.CONTAINS]: 'Contains',
+  [MATCH_TYPES.EQUALS]: 'Equals',
+  [MATCH_TYPES.REGEX]: 'Regex',
+  [MATCH_TYPES.WILDCARD]: 'Wildcard',
+  [MATCH_TYPES.STARTS_WITH]: 'Starts with',
+  [MATCH_TYPES.ENDS_WITH]: 'Ends with',
+};
+
+// ponytail: one flat list for both request and response headers, split per headerType if it gets noisy
+const STANDARD_HTTP_HEADERS = [
+  'Accept',
+  'Accept-CH',
+  'Accept-Charset',
+  'Accept-Encoding',
+  'Accept-Language',
+  'Accept-Ranges',
+  'Access-Control-Allow-Credentials',
+  'Access-Control-Allow-Headers',
+  'Access-Control-Allow-Methods',
+  'Access-Control-Allow-Origin',
+  'Access-Control-Expose-Headers',
+  'Access-Control-Max-Age',
+  'Access-Control-Request-Headers',
+  'Access-Control-Request-Method',
+  'Age',
+  'Allow',
+  'Authorization',
+  'Cache-Control',
+  'Connection',
+  'Content-Disposition',
+  'Content-Encoding',
+  'Content-Language',
+  'Content-Length',
+  'Content-Location',
+  'Content-Range',
+  'Content-Security-Policy',
+  'Content-Security-Policy-Report-Only',
+  'Content-Type',
+  'Cookie',
+  'DNT',
+  'Date',
+  'ETag',
+  'Expires',
+  'Host',
+  'If-Match',
+  'If-Modified-Since',
+  'If-None-Match',
+  'If-Range',
+  'If-Unmodified-Since',
+  'Keep-Alive',
+  'Last-Modified',
+  'Location',
+  'Origin',
+  'Pragma',
+  'Proxy-Authorization',
+  'Range',
+  'Referer',
+  'Server',
+  'Set-Cookie',
+  'Strict-Transport-Security',
+  'TE',
+  'Transfer-Encoding',
+  'User-Agent',
+  'Vary',
+  'Via',
+  'WWW-Authenticate',
+  'Warning',
+  'X-Content-Type-Options',
+  'X-Correlation-ID',
+  'X-Forwarded-For',
+  'X-Forwarded-Host',
+  'X-Forwarded-Proto',
+  'X-Frame-Options',
+  'X-Request-ID',
+  'X-Requested-With',
+  'X-XSS-Protection',
+];
+
+const fieldClassName =
+  'rounded-md border border-gray-300 px-2 py-1 text-sm focus-visible:outline-gray-400 dark:border-gray-500 dark:bg-slate-900';
+
+const newCondition = (): HeaderRuleCondition => ({
+  id: uuidv4(),
+  matchType: MATCH_TYPES.CONTAINS,
+  targetValue: '',
+  resourceType: ANY,
+  requestMethod: ANY,
+  enabled: true,
+});
+
+const newAction = (): HeaderRuleAction => ({
+  id: uuidv4(),
+  operation: HEADER_OPERATIONS.SET,
+  headerType: HEADER_TYPES.REQUEST,
+  headerName: '',
+  headerValue: '',
+  enabled: true,
+});
+
+const newRule = (): HeaderRule => ({
+  id: uuidv4(),
+  enabled: true,
+  conditions: [newCondition()],
+  actions: [newAction()],
+});
+
+const AddButton = ({label, onClick}: {label: string; onClick: () => void}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="flex items-center gap-1 rounded-md border border-dashed border-gray-400 px-2 py-1 text-xs text-gray-600 transition-colors hover:border-gray-600 hover:text-gray-900 dark:border-gray-500 dark:text-gray-300 dark:hover:border-gray-300 dark:hover:text-white"
+  >
+    <Icon icon="mdi:plus" />
+    {label}
+  </button>
+);
+
+const DeleteButton = ({title, onClick}: {title: string; onClick: () => void}) => (
+  <button
+    type="button"
+    title={title}
+    onClick={onClick}
+    className="rounded p-1 text-gray-500 transition-colors hover:bg-gray-200 hover:text-red-600 dark:hover:bg-slate-700"
+  >
+    <Icon icon="mdi:delete-outline" />
+  </button>
+);
+
+const ModifyHeadersModal = () => {
+  const isOpen = useSelector(selectIsHeaderRulesModalOpen);
+  const savedRules = useSelector(selectHeaderRules);
+  const [rules, setRules] = useState<HeaderRule[]>([]);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (isOpen) {
+      setRules(savedRules.length > 0 ? savedRules : [newRule()]);
+    }
+  }, [isOpen, savedRules]);
+
+  const onClose = () => dispatch(setHeaderRulesModalOpen(false));
+
+  const updateRule = (ruleId: string, changes: Partial<HeaderRule>) =>
+    setRules(rules.map((rule) => (rule.id === ruleId ? {...rule, ...changes} : rule)));
+
+  const updateCondition = (
+    rule: HeaderRule,
+    conditionId: string,
+    changes: Partial<HeaderRuleCondition>
+  ) =>
+    updateRule(rule.id, {
+      conditions: rule.conditions.map((condition) =>
+        condition.id === conditionId ? {...condition, ...changes} : condition
+      ),
+    });
+
+  const updateAction = (rule: HeaderRule, actionId: string, changes: Partial<HeaderRuleAction>) =>
+    updateRule(rule.id, {
+      actions: rule.actions.map((action) =>
+        action.id === actionId ? {...action, ...changes} : action
+      ),
+    });
+
+  const onSave = () => {
+    const cleanedRules = rules
+      .map((rule) => ({
+        ...rule,
+        conditions: rule.conditions.filter((condition) => condition.targetValue.trim() !== ''),
+        actions: rule.actions.filter((action) => action.headerName.trim() !== ''),
+      }))
+      .filter((rule) => rule.conditions.length > 0 && rule.actions.length > 0);
+
+    dispatch(setHeaderRules(cleanedRules));
+    // One session is shared by every preview screen, a reload applies the rules everywhere.
+    webViewPubSub.publish(NAVIGATION_EVENTS.RELOAD);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Modify Request Headers">
+      <div className="flex max-h-[70vh] w-[78vw] max-w-5xl flex-col gap-4 overflow-y-auto">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          A rule applies to a request when all of its enabled conditions match. Rules apply to every
+          preview screen.
+        </p>
+
+        {rules.map((rule, ruleIndex) => (
+          <div
+            key={rule.id}
+            className="flex flex-col gap-3 rounded-md border border-gray-300 p-3 dark:border-gray-600"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Rule {ruleIndex + 1}</span>
+              <div className="flex flex-wrap items-center gap-2">
+                <Toggle
+                  isOn={rule.enabled}
+                  onChange={(e) => updateRule(rule.id, {enabled: e.target.checked})}
+                />
+                <DeleteButton
+                  title="Delete rule"
+                  onClick={() => setRules(rules.filter((r) => r.id !== rule.id))}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                If Request
+              </span>
+              {rule.conditions.map((condition) => (
+                <div key={condition.id} className="flex flex-wrap items-center gap-2">
+                  <select
+                    aria-label="Match type"
+                    className={`w-28 ${fieldClassName}`}
+                    value={condition.matchType}
+                    onChange={(e) =>
+                      updateCondition(rule, condition.id, {
+                        matchType: e.target.value as HeaderRuleCondition['matchType'],
+                      })
+                    }
+                  >
+                    {Object.values(MATCH_TYPES).map((matchType) => (
+                      <option key={matchType} value={matchType}>
+                        {MATCH_TYPE_LABELS[matchType]}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    aria-label="Target value"
+                    placeholder="https://preprod.example.com/"
+                    className={`min-w-[12rem] flex-grow ${fieldClassName}`}
+                    value={condition.targetValue}
+                    onChange={(e) =>
+                      updateCondition(rule, condition.id, {targetValue: e.target.value})
+                    }
+                  />
+                  <select
+                    aria-label="Resource type"
+                    className={`w-32 ${fieldClassName}`}
+                    value={condition.resourceType}
+                    onChange={(e) =>
+                      updateCondition(rule, condition.id, {resourceType: e.target.value})
+                    }
+                  >
+                    {RESOURCE_TYPES.map((resourceType) => (
+                      <option key={resourceType} value={resourceType}>
+                        {resourceType === ANY ? 'Any resource' : resourceType}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    aria-label="Request method"
+                    className={`w-28 ${fieldClassName}`}
+                    value={condition.requestMethod}
+                    onChange={(e) =>
+                      updateCondition(rule, condition.id, {requestMethod: e.target.value})
+                    }
+                  >
+                    {REQUEST_METHODS.map((method) => (
+                      <option key={method} value={method}>
+                        {method === ANY ? 'Any method' : method}
+                      </option>
+                    ))}
+                  </select>
+                  <Toggle
+                    isOn={condition.enabled}
+                    onChange={(e) =>
+                      updateCondition(rule, condition.id, {enabled: e.target.checked})
+                    }
+                  />
+                  <DeleteButton
+                    title="Delete condition"
+                    onClick={() =>
+                      updateRule(rule.id, {
+                        conditions: rule.conditions.filter((c) => c.id !== condition.id),
+                      })
+                    }
+                  />
+                </div>
+              ))}
+              <AddButton
+                label="Add Condition"
+                onClick={() =>
+                  updateRule(rule.id, {conditions: [...rule.conditions, newCondition()]})
+                }
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Operator</span>
+              {rule.actions.map((action) => (
+                <div key={action.id} className="flex flex-wrap items-center gap-2">
+                  <select
+                    aria-label="Operation"
+                    className={`w-28 capitalize ${fieldClassName}`}
+                    value={action.operation}
+                    onChange={(e) =>
+                      updateAction(rule, action.id, {
+                        operation: e.target.value as HeaderRuleAction['operation'],
+                      })
+                    }
+                  >
+                    {Object.values(HEADER_OPERATIONS).map((operation) => (
+                      <option key={operation} value={operation} className="capitalize">
+                        {operation}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    aria-label="Header type"
+                    className={`w-28 ${fieldClassName}`}
+                    value={action.headerType}
+                    onChange={(e) =>
+                      updateAction(rule, action.id, {
+                        headerType: e.target.value as HeaderRuleAction['headerType'],
+                      })
+                    }
+                  >
+                    <option value={HEADER_TYPES.REQUEST}>Request</option>
+                    <option value={HEADER_TYPES.RESPONSE}>Response</option>
+                  </select>
+                  <select
+                    aria-label="Standard header names"
+                    title="Pick a standard header"
+                    className={`w-28 ${fieldClassName}`}
+                    value=""
+                    onChange={(e) => updateAction(rule, action.id, {headerName: e.target.value})}
+                  >
+                    <option value="">Standard…</option>
+                    {STANDARD_HTTP_HEADERS.map((headerName) => (
+                      <option key={headerName} value={headerName}>
+                        {headerName}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    aria-label="Header name"
+                    placeholder="x-custom-header"
+                    className={`min-w-[12rem] flex-grow ${fieldClassName}`}
+                    value={action.headerName}
+                    onChange={(e) => updateAction(rule, action.id, {headerName: e.target.value})}
+                  />
+                  <input
+                    type="text"
+                    aria-label="Header value"
+                    placeholder={
+                      action.operation === HEADER_OPERATIONS.REMOVE ? 'not needed' : 'value'
+                    }
+                    disabled={action.operation === HEADER_OPERATIONS.REMOVE}
+                    className={`min-w-[12rem] flex-grow disabled:opacity-50 ${fieldClassName}`}
+                    value={action.headerValue}
+                    onChange={(e) => updateAction(rule, action.id, {headerValue: e.target.value})}
+                  />
+                  <Toggle
+                    isOn={action.enabled}
+                    onChange={(e) => updateAction(rule, action.id, {enabled: e.target.checked})}
+                  />
+                  <DeleteButton
+                    title="Delete header"
+                    onClick={() =>
+                      updateRule(rule.id, {
+                        actions: rule.actions.filter((a) => a.id !== action.id),
+                      })
+                    }
+                  />
+                </div>
+              ))}
+              <AddButton
+                label="Add Header"
+                onClick={() => updateRule(rule.id, {actions: [...rule.actions, newAction()]})}
+              />
+            </div>
+          </div>
+        ))}
+
+        <AddButton label="Add Rule" onClick={() => setRules([...rules, newRule()])} />
+
+        <div>
+          <Button className="px-5 py-1" onClick={onSave} isPrimary isTextButton>
+            Save
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ModifyHeadersModal;

--- a/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/AddressBar/index.tsx
@@ -1,6 +1,7 @@
 import {Icon} from '@iconify/react';
 import cx from 'classnames';
 import {IPC_MAIN_CHANNELS, OpenUrlArgs} from 'common/constants';
+import {getMatchingActions} from 'common/headerRules';
 import {AuthRequestArgs} from 'main/http-basic-auth';
 import {PermissionRequestArg} from 'main/web-permissions/PermissionsManager';
 import {DragEvent, KeyboardEventHandler, useCallback, useEffect, useRef, useState} from 'react';
@@ -8,6 +9,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import Button from 'renderer/components/Button';
 import {webViewPubSub} from 'renderer/lib/pubsub';
 import {selectAddress, selectPageTitle, setAddress} from 'renderer/store/features/renderer';
+import {selectHeaderRules, setHeaderRulesModalOpen} from 'renderer/store/features/header-rules';
 import useKeyboardShortcut, {
   SHORTCUT_CHANNEL,
 } from 'renderer/components/KeyboardShortcutsManager/useKeyboardShortcut';
@@ -37,6 +39,11 @@ const AddressBar = () => {
   const [showSitePermissions, setShowSitePermissions] = useState(false);
   const address = useSelector(selectAddress);
   const pageTitle = useSelector(selectPageTitle);
+  const headerRules = useSelector(selectHeaderRules);
+  const modifiedHeaderNames = getMatchingActions(headerRules, {
+    url: address,
+    resourceType: 'mainFrame',
+  }).map((action) => action.headerName);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -247,7 +254,8 @@ const AddressBar = () => {
           type="text"
           data-testid="address-bar"
           className={cx(
-            'w-full text-ellipsis rounded-full px-2 py-1 pl-8 pr-40 dark:bg-slate-900',
+            'w-full text-ellipsis rounded-full px-2 py-1 pl-8 dark:bg-slate-900',
+            modifiedHeaderNames.length > 0 ? 'pr-[15rem]' : 'pr-40',
             {
               'rounded-bl-none rounded-br-none rounded-tl-lg rounded-tr-lg outline-none':
                 isSuggesting,
@@ -278,6 +286,20 @@ const AddressBar = () => {
           <p className="text-sm font-semibold">Drop URL Here</p>
         </div>
         <div className="absolute inset-y-0 right-0 mr-2 flex items-center">
+          {modifiedHeaderNames.length > 0 ? (
+            <button
+              type="button"
+              data-testid="modified-headers-indicator"
+              onClick={() => dispatch(setHeaderRulesModalOpen(true))}
+              className="mr-1 flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700 transition-colors hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-300 dark:hover:bg-blue-800"
+              title={`Modified headers for this URL: ${modifiedHeaderNames.join(
+                ', '
+              )} (click to edit)`}
+            >
+              <Icon icon="mdi:tune-variant" />
+              Headers
+            </button>
+          ) : null}
           <Button
             className="rounded-full"
             onClick={deleteStorage}

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/index.tsx
@@ -1,5 +1,8 @@
+import {useDispatch} from 'react-redux';
 import Notifications from 'renderer/components/Notifications/Notifications';
 import {Divider} from 'renderer/components/Divider';
+import Button from 'renderer/components/Button';
+import {setHeaderRulesModalOpen} from 'renderer/store/features/header-rules';
 import Devtools from './Devtools';
 import UITheme from './UITheme';
 import Zoom from './Zoom';
@@ -14,6 +17,8 @@ interface Props {
 }
 
 const MenuFlyout = ({closeFlyout}: Props) => {
+  const dispatch = useDispatch();
+
   return (
     <div className="absolute right-[4px] top-[26px] z-50 flex w-80 flex-col gap-2 rounded bg-slate-100 p-2 pb-0 text-sm shadow-lg ring-1 ring-slate-500 !ring-opacity-40 focus:outline-none dark:bg-slate-900 dark:ring-white dark:!ring-opacity-40">
       <Zoom />
@@ -29,6 +34,15 @@ const MenuFlyout = ({closeFlyout}: Props) => {
 
       <div>
         <Bookmark />
+        <Button
+          className="relative right-2 m-0 flex w-80 !justify-start pl-6"
+          onClick={() => {
+            dispatch(setHeaderRulesModalOpen(true));
+            closeFlyout();
+          }}
+        >
+          Modify Headers
+        </Button>
         <Settings closeFlyout={closeFlyout} />
       </div>
       <Divider />

--- a/desktop-app/src/renderer/components/ToolBar/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/index.tsx
@@ -27,6 +27,7 @@ import useKeyboardShortcut, {
 } from '../KeyboardShortcutsManager/useKeyboardShortcut';
 import Shortcuts from './Shortcuts';
 import {ColorBlindnessControls} from './ColorBlindnessControls';
+import ModifyHeadersModal from '../ModifyHeadersModal';
 
 const Divider = () => <div className="h-6 w-px bg-gray-300 dark:bg-gray-700" />;
 
@@ -133,6 +134,7 @@ const ToolBar = () => {
       </Button>
       <Menu />
       <ModalLoader isOpen={isCapturingScreenshot} onClose={handleClose} title="Screenshot" />
+      <ModifyHeadersModal />
     </div>
   );
 };

--- a/desktop-app/src/renderer/store/features/header-rules/index.ts
+++ b/desktop-app/src/renderer/store/features/header-rules/index.ts
@@ -1,0 +1,35 @@
+import {createSlice} from '@reduxjs/toolkit';
+import type {PayloadAction} from '@reduxjs/toolkit';
+import {HeaderRule} from 'common/headerRules';
+import type {RootState} from '../..';
+
+export interface HeaderRulesState {
+  headerRules: HeaderRule[];
+  isModalOpen: boolean;
+}
+
+const initialState: HeaderRulesState = {
+  headerRules: window.electron.store.get('headerRules'),
+  isModalOpen: false,
+};
+
+export const headerRulesSlice = createSlice({
+  name: 'headerRules',
+  initialState,
+  reducers: {
+    setHeaderRules: (state, action: PayloadAction<HeaderRule[]>) => {
+      state.headerRules = action.payload;
+      window.electron.store.set('headerRules', action.payload);
+    },
+    setHeaderRulesModalOpen: (state, action: PayloadAction<boolean>) => {
+      state.isModalOpen = action.payload;
+    },
+  },
+});
+
+export const {setHeaderRules, setHeaderRulesModalOpen} = headerRulesSlice.actions;
+
+export const selectHeaderRules = (state: RootState) => state.headerRules.headerRules;
+export const selectIsHeaderRulesModalOpen = (state: RootState) => state.headerRules.isModalOpen;
+
+export default headerRulesSlice.reducer;

--- a/desktop-app/src/renderer/store/index.ts
+++ b/desktop-app/src/renderer/store/index.ts
@@ -7,6 +7,7 @@ import rulersReducer from './features/ruler';
 import uiReducer from './features/ui';
 import bookmarkReducer from './features/bookmarks';
 import designOverlayReducer from './features/design-overlay';
+import headerRulesReducer from './features/header-rules';
 
 export const store = configureStore({
   reducer: {
@@ -17,6 +18,7 @@ export const store = configureStore({
     bookmarks: bookmarkReducer,
     rulers: rulersReducer,
     designOverlay: designOverlayReducer,
+    headerRules: headerRulesReducer,
   },
 });
 

--- a/desktop-app/src/store/index.ts
+++ b/desktop-app/src/store/index.ts
@@ -224,6 +224,11 @@ const schema = {
     },
     default: [],
   },
+  // Shape lives in common/headerRules.ts (HeaderRule)
+  headerRules: {
+    type: 'array',
+    default: [],
+  },
   history: {
     type: 'array',
     items: {


### PR DESCRIPTION
Adds a "Modify Headers" manager reachable from the main menu and from an indicator in the address bar. Rules are matched against the request URL (contains, equals, regex, wildcard, starts/ends with) and can be narrowed by resource type and HTTP method. Matching rules set, add or remove request and response headers.

Rules are applied in the shared session, so they take effect on every preview screen at once.

Refs #1506

# ✨ Pull Request

### 📓 Referenced Issue

<!-- Please link the related issue. Use # before the issue number and use the verbs 'fixes', 'resolves' to auto-link it, for eg, Fixes: #&lt;issue-number&gt; -->
Refs #1506

### ℹ️ About the PR

<!-- Please provide a description of your solution if it is not clear in the related issue or if the PR has a breaking change. If there is an interesting topic to discuss or you have questions or there is an issue with electron or another library that you have used. -->

Adds a native "Modify Headers" manager, so protected staging sites (CloudFront WAF, bearer tokens, bypass flags) can be tested without a proxy or a browser extension.
How it works:
- New "Modify Headers" item in the main menu opens a rule editor.
- A rule has one or more conditions and one or more header actions.
  - Condition: match type (Contains, Equals, Regex, Wildcard, Starts with, Ends with), the URL text to match, and optional resource type (Any, mainFrame, script, xhr, ...) and HTTP method filters.
  - Action: operation (Set, Add, Remove), direction (Request or Response), header name and value.
  - A rule applies when it is enabled and all of its enabled conditions match.
- Rules are applied on the shared Electron session, so they affect every device viewport at once. Request headers are handled in the existing onBeforeSendHeaders hook, response headers in the existing onHeadersReceived hook, so no extra listeners are registered.
- When the current URL matches a rule, a "Headers" badge shows up in the address bar. Clicking it opens the same editor.
- Rules are stored in electron-store under "headerRules" and all preview screens reload on save, so changes take effect right away.
Details:
- Set replaces the value, Add keeps the existing one (comma-joined for requests, appended to the array for responses), Remove deletes the header. Header names are matched case-insensitively.
- The header name field is free text, with a dropdown of standard HTTP header names for convenience.
- No new dependencies. Unit tests for the matching and header logic are in desktop-app/src/common/headerRules.test.ts.

### 🖼️ Testing Scenarios / Screenshots

<!-- Please include screenshots or gif to showcase the final output. Also, try to explain the testing you did to validate your change.  -->

<img width="322" height="462" alt="image" src="https://github.com/user-attachments/assets/e3c379ca-15c4-4c2c-ad3d-39efb656e47e" />

<img width="901" height="547" alt="image" src="https://github.com/user-attachments/assets/c5e89941-579e-4ea3-874b-a7a15648f6c5" />

