### PR TITLE
a11y: accessible names for toolbar zoom + theme-toggle buttons

### DIFF
--- a/desktop-app/src/renderer/components/ToolBar/ColorSchemeToggle/index.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/ColorSchemeToggle/index.tsx
@@ -19,6 +19,8 @@ const ColorSchemeToggle = () => {
       }}
       subtle
       title="Device theme color toggle"
+      aria-label="Toggle device color scheme"
+      aria-pressed={isDarkColorScheme}
     >
       <span className="relative">
         <Icon icon="iconoir:empty-page" />

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Zoom.test.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Zoom.test.tsx
@@ -1,0 +1,32 @@
+import {render, screen} from '@testing-library/react';
+import Zoom from './Zoom';
+
+// Zoom reads the current zoom factor from the store; the value itself is
+// irrelevant to these accessibility assertions, so a constant suffices.
+vi.mock('react-redux', () => ({
+  useSelector: () => 1,
+  useDispatch: () => vi.fn(),
+}));
+
+vi.mock('renderer/components/KeyboardShortcutsManager/useKeyboardShortcut', () => ({
+  default: vi.fn(),
+  SHORTCUT_CHANNEL: {},
+}));
+
+vi.mock('renderer/store/features/renderer', () => ({
+  selectZoomFactor: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+}));
+
+describe('Zoom controls accessibility', () => {
+  it('exposes an accessible name on the zoom-out button', () => {
+    render(<Zoom />);
+    expect(screen.getByRole('button', {name: /zoom out/i})).toBeInTheDocument();
+  });
+
+  it('exposes an accessible name on the zoom-in button', () => {
+    render(<Zoom />);
+    expect(screen.getByRole('button', {name: /zoom in/i})).toBeInTheDocument();
+  });
+});

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Zoom.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Zoom.tsx
@@ -9,11 +9,12 @@ import {selectZoomFactor, zoomIn, zoomOut} from 'renderer/store/features/rendere
 interface ZoomButtonProps {
   children: React.ReactNode;
   onClick: () => void;
+  label: string;
 }
 
-const ZoomButton = ({children, onClick}: ZoomButtonProps) => {
+const ZoomButton = ({children, onClick, label}: ZoomButtonProps) => {
   return (
-    <Button className="p-0 px-2" onClick={onClick} subtle>
+    <Button className="p-0 px-2" onClick={onClick} subtle aria-label={label} title={label}>
       {children}
     </Button>
   );
@@ -38,9 +39,13 @@ const Zoom = () => {
     <div className="flex flex-row items-center justify-start px-4">
       <span className="w-1/2">Zoom</span>
       <div className="flex w-fit items-center gap-2 border-l px-4 dark:border-slate-400">
-        <ZoomButton onClick={onZoomOut}>-</ZoomButton>
+        <ZoomButton onClick={onZoomOut} label="Zoom out">
+          -
+        </ZoomButton>
         <span className="w-10 text-center">{Math.ceil(zoomfactor * 100)}%</span>
-        <ZoomButton onClick={onZoomIn}>+</ZoomButton>
+        <ZoomButton onClick={onZoomIn} label="Zoom in">
+          +
+        </ZoomButton>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Small accessibility fix for two toolbar controls that were invisible to assistive tech.

- **Zoom flyout** (`Zoom.tsx`): the zoom-out (`-`) and zoom-in (`+`) buttons rendered only a glyph as their content, so screen readers / axe-core flagged them as nameless buttons (`button-name`, WCAG 2.1 4.1.2). `ZoomButton` now takes a `label` prop forwarded as `aria-label` + `title`, exposing **Zoom out** / **Zoom in**.
- **Theme toggle** (`ColorSchemeToggle/index.tsx`): it is a toggle button that never exposed its state, so a screen reader could not tell whether the dark scheme was active (WCAG 4.1.2 name/role/value). Added `aria-label` and `aria-pressed` reflecting the current `isDarkColorScheme` state. `Button` already spreads these onto the underlying `<button>`.
- **`Zoom.test.tsx`** (new): asserts both zoom buttons are reachable by accessible name — red before the fix, green after — mirroring the existing vitest + testing-library conventions.

## Why this is safe to merge

- No visual change: these are accessibility semantics only; layout, styling, and the existing `data-testid`s (used by the Playwright e2e suite) are untouched.
- No issue was filed for this; it was found by inspection. Happy to retarget if you track it under a ticket.

## Verification (run locally against the project toolchain)

- `vitest run` on the new test: 2/2 pass
- `tsc --noEmit`: clean (exit 0, 0 errors)
- `eslint` on the changed files: clean
- `prettier --check` on the changed files: all matched

## Note on the commit

Committed with `--no-verify`. The repo's husky pre-commit hook fails to spawn `cross-env` in this monorepo checkout (the binary lives under `desktop-app/node_modules/.bin` while the hook runs from the repo root, so it errors with `ENOENT` before doing any work). The checks that hook performs (`eslint --fix` + prettier via lint-staged) were run and pass independently, as shown above, and CI runs lint through the `lint` script rather than the hook. Flagging this so it is not a surprise in review.
