### PR TITLE
feat: implement exponential smooth pinch to zoom

### DIFF
--- a/desktop-app/src/main/preload-webview.ts
+++ b/desktop-app/src/main/preload-webview.ts
@@ -16,22 +16,26 @@ const documentBodyInit = () => {
     });
   });
 
-  window.addEventListener('wheel', (e) => {
-    if (e.ctrlKey) {
-      e.preventDefault(); // Prevent webview from zooming internally
-    }
-    ipcRenderer.sendToHost('pass-scroll-data', {
-      coordinates: {
-        x: e.deltaX,
-        y: e.deltaY,
-        scrollX: window.scrollX,
-        scrollY: window.scrollY,
-      },
-      ctrlKey: e.ctrlKey,
-      innerHeight: document.body.scrollHeight,
-      innerWidth: window.innerWidth,
-    });
-  }, {passive: false});
+  window.addEventListener(
+    'wheel',
+    (e) => {
+      if (e.ctrlKey) {
+        e.preventDefault(); // Prevent webview from zooming internally
+      }
+      ipcRenderer.sendToHost('pass-scroll-data', {
+        coordinates: {
+          x: e.deltaX,
+          y: e.deltaY,
+          scrollX: window.scrollX,
+          scrollY: window.scrollY,
+        },
+        ctrlKey: e.ctrlKey,
+        innerHeight: document.body.scrollHeight,
+        innerWidth: window.innerWidth,
+      });
+    },
+    {passive: false}
+  );
 
   window.addEventListener('scroll', () => {
     ipcRenderer.sendToHost('pass-scroll-data', {

--- a/desktop-app/src/main/preload-webview.ts
+++ b/desktop-app/src/main/preload-webview.ts
@@ -17,6 +17,9 @@ const documentBodyInit = () => {
   });
 
   window.addEventListener('wheel', (e) => {
+    if (e.ctrlKey) {
+      e.preventDefault(); // Prevent webview from zooming internally
+    }
     ipcRenderer.sendToHost('pass-scroll-data', {
       coordinates: {
         x: e.deltaX,
@@ -24,10 +27,11 @@ const documentBodyInit = () => {
         scrollX: window.scrollX,
         scrollY: window.scrollY,
       },
+      ctrlKey: e.ctrlKey,
       innerHeight: document.body.scrollHeight,
       innerWidth: window.innerWidth,
     });
-  });
+  }, {passive: false});
 
   window.addEventListener('scroll', () => {
     ipcRenderer.sendToHost('pass-scroll-data', {

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -39,8 +39,6 @@ import {
   setIsInspecting,
   setLayout,
   setPageTitle,
-  zoomIn,
-  zoomOut,
   zoomBy,
 } from 'renderer/store/features/renderer';
 import type {RootState} from '../../../store';
@@ -313,7 +311,6 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     }
     const webview = ref.current as Electron.WebviewTag;
     const handlerRemovers: (() => void)[] = [];
-    const accumulatedDeltaRef = { current: 0 };
 
     const didNavigateHandler = (e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent) => {
       // Only DidNavigateInPageEvent has isMainFrame
@@ -560,8 +557,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const scaledHeight = height * zoomfactor;
   const scaledWidth = width * zoomfactor;
 
-  const isRestrictedMinimumDeviceSize =
-    device.width < 400 && !isDeviceRotationEnabled;
+  const isRestrictedMinimumDeviceSize = device.width < 400 && !isDeviceRotationEnabled;
 
   return (
     <div

--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -39,6 +39,9 @@ import {
   setIsInspecting,
   setLayout,
   setPageTitle,
+  zoomIn,
+  zoomOut,
+  zoomBy,
 } from 'renderer/store/features/renderer';
 import type {RootState} from '../../../store';
 import {selectDesignOverlay, type ViewResolution} from '../../../store/features/design-overlay';
@@ -310,6 +313,7 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
     }
     const webview = ref.current as Electron.WebviewTag;
     const handlerRemovers: (() => void)[] = [];
+    const accumulatedDeltaRef = { current: 0 };
 
     const didNavigateHandler = (e: Electron.DidNavigateEvent | Electron.DidNavigateInPageEvent) => {
       // Only DidNavigateInPageEvent has isMainFrame
@@ -334,14 +338,20 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
 
     const ipcMessageHandler = (e: Electron.IpcMessageEvent) => {
       if (e.channel === 'pass-scroll-data') {
-        setCoordinates({
-          deltaX: e.args[0].coordinates.x,
-          deltaY: e.args[0].coordinates.y,
-          scrollX: e.args[0].coordinates.scrollX,
-          scrollY: e.args[0].coordinates.scrollY,
-          innerHeight: e.args[0].innerHeight,
-          innerWidth: e.args[0].innerWidth,
-        });
+        const payload = e.args[0];
+        if (payload.ctrlKey) {
+          // Pass the raw deltaY to the store to handle exponential smooth zoom
+          dispatch(zoomBy(payload.coordinates.y));
+        } else {
+          setCoordinates({
+            deltaX: payload.coordinates.x,
+            deltaY: payload.coordinates.y,
+            scrollX: payload.coordinates.scrollX,
+            scrollY: payload.coordinates.scrollY,
+            innerHeight: payload.innerHeight,
+            innerWidth: payload.innerWidth,
+          });
+        }
       }
       if (e.channel === 'context-menu-command') {
         const {command, arg} = e.args[0];
@@ -551,12 +561,12 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
   const scaledWidth = width * zoomfactor;
 
   const isRestrictedMinimumDeviceSize =
-    device.width < 400 && zoomfactor < 0.6 && !isDeviceRotationEnabled;
+    device.width < 400 && !isDeviceRotationEnabled;
 
   return (
     <div
       className={cx('h-fit', {
-        'w-52': isRestrictedMinimumDeviceSize,
+        'min-w-[14rem]': isRestrictedMinimumDeviceSize,
       })}
     >
       <div className="flex justify-between">

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -1,11 +1,11 @@
-import {useSelector} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
 import cx from 'classnames';
 import {selectActiveSuite} from 'renderer/store/features/device-manager';
 import {DOCK_POSITION, PREVIEW_LAYOUTS} from 'common/constants';
 import {selectDockPosition, selectIsDevtoolsOpen} from 'renderer/store/features/devtools';
 import {getDevicesMap, Device as IDevice} from 'common/deviceList';
-import {useState} from 'react';
-import {selectLayout} from 'renderer/store/features/renderer';
+import {useState, useEffect, useRef} from 'react';
+import {selectLayout, zoomIn, zoomOut, zoomBy} from 'renderer/store/features/renderer';
 import Masonry from 'react-masonry-component';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
@@ -28,13 +28,35 @@ const TypedMasonry: React.FC<MasonryProps> = Masonry as any;
 
 const Previewer = () => {
   const activeSuite = useSelector(selectActiveSuite);
-  const devices = activeSuite.devices.map((id) => getDevicesMap()[id]);
+  const devices = activeSuite.devices.map((id: string) => getDevicesMap()[id]);
   const dockPosition = useSelector(selectDockPosition);
   const isDevtoolsOpen = useSelector(selectIsDevtoolsOpen);
   const layout = useSelector(selectLayout);
   const [individualDevice, setIndividualDevice] = useState<IDevice>(devices[0]);
   const isIndividualLayout = layout === PREVIEW_LAYOUTS.INDIVIDUAL;
   const isMasonryLayout = layout === PREVIEW_LAYOUTS.MASONRY; // New state for Masonry layout
+  const dispatch = useDispatch();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const accumulatedDeltaRef = useRef(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey) {
+        e.preventDefault();
+        // Pass the raw deltaY to the store to handle exponential smooth zoom
+        dispatch(zoomBy(e.deltaY));
+      }
+    };
+
+    container.addEventListener('wheel', handleWheel, {passive: false});
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+    };
+  }, [dispatch]);
 
   const masonryOptions = {
     columnWidth: 275,
@@ -60,11 +82,11 @@ const Previewer = () => {
           'justify-center': isIndividualLayout,
         })}
       >
-        <div className="flex flex-grow overflow-hidden">
+        <div className="flex flex-grow overflow-hidden" ref={containerRef}>
           <div className="w-full flex-grow overflow-y-auto" style={{height: '100%'}}>
             {isMasonryLayout ? (
               <TypedMasonry options={masonryOptions} className="w-full gap-4 p-2">
-                {devices.map((device) => (
+                {devices.map((device: IDevice) => (
                   <div key={device.id} className="device-item p-4">
                     <Device
                       device={device}
@@ -89,7 +111,7 @@ const Previewer = () => {
                     setIndividualDevice={setIndividualDevice}
                   />
                 ) : (
-                  devices.map((device, idx) => (
+                  devices.map((device: IDevice, idx: number) => (
                     <Device
                       key={device.id}
                       device={device}

--- a/desktop-app/src/renderer/components/Previewer/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/index.tsx
@@ -5,7 +5,7 @@ import {DOCK_POSITION, PREVIEW_LAYOUTS} from 'common/constants';
 import {selectDockPosition, selectIsDevtoolsOpen} from 'renderer/store/features/devtools';
 import {getDevicesMap, Device as IDevice} from 'common/deviceList';
 import {useState, useEffect, useRef} from 'react';
-import {selectLayout, zoomIn, zoomOut, zoomBy} from 'renderer/store/features/renderer';
+import {selectLayout, zoomBy} from 'renderer/store/features/renderer';
 import Masonry from 'react-masonry-component';
 import Device from './Device';
 import DevtoolsResizer from './DevtoolsResizer';
@@ -37,8 +37,6 @@ const Previewer = () => {
   const isMasonryLayout = layout === PREVIEW_LAYOUTS.MASONRY; // New state for Masonry layout
   const dispatch = useDispatch();
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const accumulatedDeltaRef = useRef(0);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/desktop-app/src/renderer/store/features/renderer/index.ts
+++ b/desktop-app/src/renderer/store/features/renderer/index.ts
@@ -62,38 +62,51 @@ export const rendererSlice = createSlice({
       }
     },
     zoomIn: (state) => {
-      const index =
-        state.layout === PREVIEW_LAYOUTS.INDIVIDUAL
-          ? zoomSteps.indexOf(state.individualZoomFactor)
-          : zoomSteps.indexOf(state.zoomFactor);
-
-      if (index < zoomSteps.length - 1) {
+      const currentZoom = state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
+      const nextStep = zoomSteps.find((step) => step > currentZoom + 0.001); // +0.001 to handle floating point precision
+      
+      if (nextStep) {
+        const newIndex = zoomSteps.indexOf(nextStep);
         if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
-          const newIndex = index + 1;
-          state.individualZoomFactor = zoomSteps[newIndex];
+          state.individualZoomFactor = nextStep;
           window.electron.store.set('renderer.individualZoomStepIndex', newIndex);
         } else {
-          const newIndex = index + 1;
-          state.zoomFactor = zoomSteps[newIndex];
+          state.zoomFactor = nextStep;
           window.electron.store.set('renderer.zoomStepIndex', newIndex);
         }
       }
     },
     zoomOut: (state) => {
-      const index =
-        state.layout === PREVIEW_LAYOUTS.INDIVIDUAL
-          ? zoomSteps.indexOf(state.individualZoomFactor)
-          : zoomSteps.indexOf(state.zoomFactor);
-      if (index > 0) {
+      const currentZoom = state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
+      const nextStep = [...zoomSteps].reverse().find((step) => step < currentZoom - 0.001);
+      
+      if (nextStep) {
+        const newIndex = zoomSteps.indexOf(nextStep);
         if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
-          const newIndex = index - 1;
-          state.individualZoomFactor = zoomSteps[newIndex];
+          state.individualZoomFactor = nextStep;
           window.electron.store.set('renderer.individualZoomStepIndex', newIndex);
         } else {
-          const newIndex = index - 1;
-          state.zoomFactor = zoomSteps[newIndex];
+          state.zoomFactor = nextStep;
           window.electron.store.set('renderer.zoomStepIndex', newIndex);
         }
+      }
+    },
+    zoomBy: (state, action: PayloadAction<number>) => {
+      const deltaY = action.payload;
+      const MIN_ZOOM = zoomSteps[0];
+      const MAX_ZOOM = zoomSteps[zoomSteps.length - 1];
+      
+      // Use an exponential scale so the perceived zoom speed is consistent across all zoom levels
+      const multiplier = Math.exp(-deltaY * 0.002);
+      
+      if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
+        let newZoom = state.individualZoomFactor * multiplier;
+        newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+        state.individualZoomFactor = newZoom;
+      } else {
+        let newZoom = state.zoomFactor * multiplier;
+        newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+        state.zoomFactor = newZoom;
       }
     },
     setRotate: (state, action: PayloadAction<boolean>) => {
@@ -127,6 +140,7 @@ export const {
   setAddress,
   zoomIn,
   zoomOut,
+  zoomBy,
   setRotate,
   setIsInspecting,
   setLayout,

--- a/desktop-app/src/renderer/store/features/renderer/index.ts
+++ b/desktop-app/src/renderer/store/features/renderer/index.ts
@@ -62,9 +62,10 @@ export const rendererSlice = createSlice({
       }
     },
     zoomIn: (state) => {
-      const currentZoom = state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
+      const currentZoom =
+        state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
       const nextStep = zoomSteps.find((step) => step > currentZoom + 0.001); // +0.001 to handle floating point precision
-      
+
       if (nextStep) {
         const newIndex = zoomSteps.indexOf(nextStep);
         if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
@@ -77,9 +78,10 @@ export const rendererSlice = createSlice({
       }
     },
     zoomOut: (state) => {
-      const currentZoom = state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
+      const currentZoom =
+        state.layout === PREVIEW_LAYOUTS.INDIVIDUAL ? state.individualZoomFactor : state.zoomFactor;
       const nextStep = [...zoomSteps].reverse().find((step) => step < currentZoom - 0.001);
-      
+
       if (nextStep) {
         const newIndex = zoomSteps.indexOf(nextStep);
         if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
@@ -95,10 +97,10 @@ export const rendererSlice = createSlice({
       const deltaY = action.payload;
       const MIN_ZOOM = zoomSteps[0];
       const MAX_ZOOM = zoomSteps[zoomSteps.length - 1];
-      
+
       // Use an exponential scale so the perceived zoom speed is consistent across all zoom levels
       const multiplier = Math.exp(-deltaY * 0.002);
-      
+
       if (state.layout === PREVIEW_LAYOUTS.INDIVIDUAL) {
         let newZoom = state.individualZoomFactor * multiplier;
         newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));


### PR DESCRIPTION
### 📓 Referenced Issue
Fixes #1049
![Uploading ZoomIssueFix.gif…]()


### ℹ️ About the PR
- Updated `preload-webview.ts` to forward the `ctrlKey` with `pass-scroll-data` IPC events, allowing the app to detect trackpad pinch gestures even when the cursor is hovering over a webview.
- Implemented **exponential smooth continuous zoom** by introducing a new `zoomBy` Redux action. The zoom scale now updates smoothly based on the scroll `deltaY` (using `Math.exp`), providing a native-like butter-smooth zooming experience across all zoom levels without jerky steps.
- Fixed a layout bug in `Previewer/Device/index.tsx` where zooming out below 60% caused the device container to jump in width and clip the toolbar buttons. Replaced the hardcoded `w-52` conditional class with a responsive `min-w-[14rem]` class.

### 🖼️ Testing Scenarios / Screenshots
- Tested pinch-to-zoom over the empty previewer space (zooms smoothly).
- Tested pinch-to-zoom while hovering directly over device webviews (zooms smoothly without getting trapped inside the iframe).
- Verified that device toolbar buttons remain visible and properly aligned even at extremely low zoom levels (e.g. 20%).
