### PR TITLE
feat: add preference to disable auto-hidden scrollbars on mobile previews

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/index.tsx
@@ -517,6 +517,11 @@ const Device = ({isPrimary, device, setIndividualDevice}: Props) => {
       return;
     }
 
+    const hideMobileScrollbars = window.electron.store.get('userPreferences.hideMobileScrollbars');
+    if (!hideMobileScrollbars) {
+      return;
+    }
+
     const webview = ref.current;
     webview.addEventListener('dom-ready', () => {
       webview.insertCSS(`

--- a/desktop-app/src/renderer/components/Toggle/index.tsx
+++ b/desktop-app/src/renderer/components/Toggle/index.tsx
@@ -1,16 +1,19 @@
 interface Props {
   isOn: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  id?: string;
+  'data-testid'?: string;
 }
 
-const Toggle = ({isOn, onChange}: Props) => {
+const Toggle = ({isOn, onChange, id = 'small-toggle', 'data-testid': dataTestId}: Props) => {
   return (
     // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label className="relative inline-flex cursor-pointer items-center">
       <input
         type="checkbox"
         checked={isOn}
-        id="small-toggle"
+        id={id}
+        data-testid={dataTestId}
         className="peer sr-only"
         onChange={onChange}
       />

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.test.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.test.tsx
@@ -35,4 +35,34 @@ describe('SettingsContentHeader', () => {
 
     expect(mockOnClose).toHaveBeenCalled();
   });
+
+  it('Hide mobile scrollbars preference is saved to store', () => {
+    vi.mocked(window.electron.store.get).mockImplementation((key: string) => {
+      if (key === 'userPreferences.hideMobileScrollbars') {
+        return true;
+      }
+      if (key === 'userPreferences.screenshot.saveLocation') {
+        return './path/location';
+      }
+      return undefined;
+    });
+
+    const {getByTestId} = renderComponent();
+
+    const hideMobileScrollbarsToggle = getByTestId('settings-hide_mobile_scrollbars-toggle');
+    const saveButton = getByTestId('settings-save-button');
+
+    expect(hideMobileScrollbarsToggle).toBeChecked();
+
+    fireEvent.click(hideMobileScrollbarsToggle);
+    fireEvent.click(saveButton);
+
+    expect(hideMobileScrollbarsToggle).not.toBeChecked();
+    expect(window.electron.store.set).toHaveBeenCalledWith(
+      'userPreferences.hideMobileScrollbars',
+      false
+    );
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
 });

--- a/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
+++ b/desktop-app/src/renderer/components/ToolBar/Menu/Flyout/Settings/SettingsContent.tsx
@@ -1,6 +1,7 @@
 import {useId, useState} from 'react';
 
 import Button from 'renderer/components/Button';
+import Toggle from 'renderer/components/Toggle';
 import {SettingsContentHeaders} from './SettingsContentHeaders';
 
 interface Props {
@@ -9,11 +10,15 @@ interface Props {
 
 export const SettingsContent = ({onClose}: Props) => {
   const id = useId();
+  const hideMobileScrollbarsId = useId();
   const [screenshotSaveLocation, setScreenshotSaveLocation] = useState<string>(
     window.electron.store.get('userPreferences.screenshot.saveLocation')
   );
   const [webRequestHeaderAcceptLanguage, setWebRequestHeaderAcceptLanguage] = useState<string>(
     window.electron.store.get('userPreferences.webRequestHeaderAcceptLanguage')
+  );
+  const [hideMobileScrollbars, setHideMobileScrollbars] = useState<boolean>(
+    window.electron.store.get('userPreferences.hideMobileScrollbars')
   );
 
   const onSave = () => {
@@ -29,6 +34,8 @@ export const SettingsContent = ({onClose}: Props) => {
       'userPreferences.webRequestHeaderAcceptLanguage',
       webRequestHeaderAcceptLanguage
     );
+
+    window.electron.store.set('userPreferences.hideMobileScrollbars', hideMobileScrollbars);
 
     onClose();
   };
@@ -52,6 +59,25 @@ export const SettingsContent = ({onClose}: Props) => {
           <p className="text-sm text-gray-500 dark:text-gray-400">
             The location where screenshots will be saved.
           </p>
+        </div>
+      </div>
+
+      <h2>Mobile Preview</h2>
+      <div className="my-4 flex flex-col space-y-4 text-sm">
+        <div className="flex items-center justify-between">
+          <label htmlFor={hideMobileScrollbarsId} className="flex flex-col">
+            Hide scrollbars on mobile devices
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              Mimics the scrollbar behaviour of real mobile devices. Disable to always show
+              scrollbars.
+            </span>
+          </label>
+          <Toggle
+            id={hideMobileScrollbarsId}
+            data-testid="settings-hide_mobile_scrollbars-toggle"
+            isOn={hideMobileScrollbars}
+            onChange={(e) => setHideMobileScrollbars(e.target.checked)}
+          />
         </div>
       </div>
 

--- a/desktop-app/src/store/index.ts
+++ b/desktop-app/src/store/index.ts
@@ -148,6 +148,10 @@ const schema = {
         type: 'boolean',
         default: false,
       },
+      hideMobileScrollbars: {
+        type: 'boolean',
+        default: true,
+      },
       guides: {
         type: 'array',
         items: {


### PR DESCRIPTION
### 📓 Referenced Issue

Fixes #1167

### ℹ️ About the PR

Mobile-capable device previews always hide scrollbars (via an injected `::-webkit-scrollbar { display: none; }` rule) to mimic real mobile devices, with no way to opt out. This was reported as a bug in #1167, and the maintainer suggested adding a preferences option to disable this default.

This PR adds a `userPreferences.hideMobileScrollbars` preference (default: `true`, so existing behavior is unchanged) with a toggle in the Settings panel under a new "Mobile Preview" section. When disabled, the scrollbar-hiding CSS is no longer injected into mobile-capable device webviews, so scrollbars behave like they would in a normal browser.

The new setting sits right below the existing Screenshots section in the Settings dialog, following the same layout/label pattern as the other preferences there.

### 🖼️ Testing Scenarios / Screenshots

- Added a unit test in `SettingsContent.test.tsx` covering that the toggle reflects the stored preference and persists changes on save.
- Ran `yarn lint`, `yarn exec tsc`, `yarn test` (all passing) and `yarn build` (production build succeeds) locally.
- Manually verified in the running app: opened Settings, confirmed the new "Hide scrollbars on mobile devices" toggle defaults to on, toggled it off, saved, reloaded a mobile-capable device preview, and confirmed via devtools that the preference is respected and persists across reopening the Settings panel.

Happy to attach a screenshot of the Settings panel here if it'd help review — just let me know.