### PR TITLE
feat: collapse overflowing device toolbar icons into a dropdown

### DIFF
--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar/OverflowMenu.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar/OverflowMenu.tsx
@@ -1,0 +1,38 @@
+import {Popover, Transition} from '@headlessui/react';
+import {Float} from '@headlessui-float/react';
+import {Icon} from '@iconify/react';
+import {Fragment, ReactNode} from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+const OverflowMenu = ({children}: Props) => {
+  return (
+    <Popover>
+      <Float placement="bottom-end" flip portal>
+        <Popover.Button
+          title="More Options"
+          className="flex items-center justify-center rounded-sm p-1 hover:bg-slate-400 focus:outline-none dark:hover:bg-slate-600"
+        >
+          <Icon icon="mdi:dots-vertical" />
+        </Popover.Button>
+        <Transition
+          as={Fragment}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <Popover.Panel className="z-50 mt-2 flex w-fit flex-wrap gap-1 rounded-md bg-slate-100 p-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-slate-900">
+            {children}
+          </Popover.Panel>
+        </Transition>
+      </Float>
+    </Popover>
+  );
+};
+
+export default OverflowMenu;

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar/index.tsx
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar/index.tsx
@@ -8,8 +8,10 @@ import WebPage from 'main/screenshot/webpage';
 
 import screenshotSfx from 'renderer/assets/sfx/screenshot.mp3';
 import {updateWebViewHeightAndScale} from 'common/webViewUtils';
-import {ColorBlindnessTools} from './ColorBlindnessTools';
-import DesignOverlayControls from './DesignOverlayControls';
+import {ColorBlindnessTools} from '../ColorBlindnessTools';
+import DesignOverlayControls from '../DesignOverlayControls';
+import OverflowMenu from './OverflowMenu';
+import {useResponsiveToolbarItems} from './useResponsiveToolbarItems';
 
 interface Props {
   webview: Electron.WebviewTag | null;
@@ -22,6 +24,8 @@ interface Props {
   isIndividualLayout: boolean;
   isDeviceRotationEnabled: boolean;
 }
+
+const TOOLBAR_ITEMS_GAP = 4; // matches the `gap-1` tailwind class below
 
 const Toolbar = ({
   webview,
@@ -139,12 +143,18 @@ const Toolbar = ({
     }
   };
 
-  return (
-    <div className="flex items-center justify-between gap-1">
-      <div className="my-1 inline-flex max-w-[78%] items-center gap-1 overflow-x-auto">
+  const toolbarItems = [
+    {
+      key: 'refresh',
+      node: (
         <Button onClick={refreshView} title="Refresh This View">
           <Icon icon="ic:round-refresh" />
         </Button>
+      ),
+    },
+    {
+      key: 'quick-screenshot',
+      node: (
         <Button onClick={quickScreenshot} isLoading={screenshotLoading} title="Quick Screenshot">
           <div className="relative h-4 w-4">
             <Icon icon="ic:outline-photo-camera" className="absolute left-0 top-0" />
@@ -155,6 +165,11 @@ const Toolbar = ({
             />
           </div>
         </Button>
+      ),
+    },
+    {
+      key: 'full-screenshot',
+      node: (
         <Button
           onClick={fullScreenshot}
           isLoading={fullScreenshotLoading}
@@ -162,9 +177,19 @@ const Toolbar = ({
         >
           <Icon icon="ic:outline-photo-camera" />
         </Button>
+      ),
+    },
+    {
+      key: 'design-overlay',
+      node: (
         <Button onClick={() => setIsDesignOverlayModalOpen(true)} title="Design Overlay">
           <Icon icon="lucide:layers" />
         </Button>
+      ),
+    },
+    {
+      key: 'event-mirroring',
+      node: (
         <Button
           onClick={toggleEventMirroring}
           isActive={eventMirroringOff}
@@ -172,9 +197,19 @@ const Toolbar = ({
         >
           <Icon icon="fluent:plug-disconnected-24-regular" />
         </Button>
+      ),
+    },
+    {
+      key: 'devtools',
+      node: (
         <Button onClick={openDevTools} title="Open Devtools">
           <Icon icon="ic:round-code" />
         </Button>
+      ),
+    },
+    {
+      key: 'rotate',
+      node: (
         <Button
           onClick={rotate}
           disabled={!isDeviceRotationEnabled}
@@ -186,13 +221,52 @@ const Toolbar = ({
         >
           <Icon icon={rotated ? 'mdi:phone-rotate-portrait' : 'mdi:phone-rotate-landscape'} />
         </Button>
+      ),
+    },
+    {
+      key: 'scroll-to-top',
+      node: (
         <Button onClick={scrollToTop} title="Scroll to Top">
           <Icon icon="ic:baseline-arrow-upward" />
         </Button>
+      ),
+    },
+    {
+      key: 'rulers',
+      node: (
         <Button onClick={toggleRulers} title="Show rulers">
           <Icon icon="tdesign:measurement-1" />
         </Button>
-        <ColorBlindnessTools webview={webview} />
+      ),
+    },
+    {
+      key: 'color-blindness',
+      node: <ColorBlindnessTools webview={webview} />,
+    },
+  ];
+
+  const {containerRef, firstItemRef, visibleCount} = useResponsiveToolbarItems(
+    toolbarItems.length,
+    TOOLBAR_ITEMS_GAP
+  );
+  const visibleItems = toolbarItems.slice(0, visibleCount);
+  const overflowItems = toolbarItems.slice(visibleCount);
+
+  return (
+    <div className="flex items-center justify-between gap-1">
+      <div ref={containerRef} className="my-1 flex max-w-[78%] items-center gap-1 overflow-hidden">
+        {visibleItems.map((item, idx) => (
+          <div key={item.key} ref={idx === 0 ? firstItemRef : undefined}>
+            {item.node}
+          </div>
+        ))}
+        {overflowItems.length > 0 && (
+          <OverflowMenu>
+            {overflowItems.map((item) => (
+              <div key={item.key}>{item.node}</div>
+            ))}
+          </OverflowMenu>
+        )}
       </div>
       <Button
         onClick={() => onIndividualLayoutHandler(device)}

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar/useResponsiveToolbarItems.test.ts
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar/useResponsiveToolbarItems.test.ts
@@ -1,0 +1,46 @@
+import {calculateVisibleItemCount} from './useResponsiveToolbarItems';
+
+describe('calculateVisibleItemCount', () => {
+  it('returns all items when everything fits within the container', () => {
+    expect(calculateVisibleItemCount(400, 10, 28, 4)).toBe(10);
+  });
+
+  it('returns all items when the container width exactly matches the required width', () => {
+    // 5 items * 28 + 4 gaps * 4 = 140 + 16 = 156
+    expect(calculateVisibleItemCount(156, 5, 28, 4)).toBe(5);
+  });
+
+  it('reserves room for the overflow trigger when not everything fits', () => {
+    // 10 items don't fit in 200px, so some must move to the overflow trigger.
+    const visibleCount = calculateVisibleItemCount(200, 10, 28, 4);
+    expect(visibleCount).toBeLessThan(10);
+    expect(visibleCount).toBeGreaterThan(0);
+  });
+
+  it('never returns more items than would fit alongside the overflow trigger', () => {
+    const containerWidth = 200;
+    const itemWidth = 28;
+    const gap = 4;
+    const visibleCount = calculateVisibleItemCount(containerWidth, 10, itemWidth, gap);
+
+    const visibleWidth = visibleCount * itemWidth + Math.max(visibleCount - 1, 0) * gap;
+    const withTriggerWidth = visibleWidth + gap + itemWidth;
+    expect(withTriggerWidth).toBeLessThanOrEqual(containerWidth);
+  });
+
+  it('returns 0 when even a single item cannot fit alongside the overflow trigger', () => {
+    expect(calculateVisibleItemCount(30, 10, 28, 4)).toBe(0);
+  });
+
+  it('falls back to returning all items when the container has not been measured yet', () => {
+    expect(calculateVisibleItemCount(0, 6, 28, 4)).toBe(6);
+  });
+
+  it('falls back to returning all items when the item width is unknown', () => {
+    expect(calculateVisibleItemCount(300, 6, 0, 4)).toBe(6);
+  });
+
+  it('returns 0 for an empty item list', () => {
+    expect(calculateVisibleItemCount(300, 0, 28, 4)).toBe(0);
+  });
+});

--- a/desktop-app/src/renderer/components/Previewer/Device/Toolbar/useResponsiveToolbarItems.ts
+++ b/desktop-app/src/renderer/components/Previewer/Device/Toolbar/useResponsiveToolbarItems.ts
@@ -1,0 +1,67 @@
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
+
+export function calculateVisibleItemCount(
+  containerWidth: number,
+  itemCount: number,
+  itemWidth: number,
+  gap: number
+): number {
+  if (containerWidth <= 0 || itemWidth <= 0 || itemCount <= 0) {
+    return itemCount;
+  }
+
+  const totalWidth = itemCount * itemWidth + (itemCount - 1) * gap;
+  if (totalWidth <= containerWidth) {
+    return itemCount;
+  }
+
+  // Not everything fits, so reserve room for the overflow trigger (same size as a regular item).
+  const budget = containerWidth - itemWidth - gap;
+
+  let usedWidth = 0;
+  let fitCount = 0;
+  for (let i = 0; i < itemCount; i += 1) {
+    const nextWidth = usedWidth + (i === 0 ? 0 : gap) + itemWidth;
+    if (nextWidth > budget) {
+      break;
+    }
+    usedWidth = nextWidth;
+    fitCount += 1;
+  }
+  return fitCount;
+}
+
+/**
+ * Measures the toolbar container and its first item to figure out how many
+ * same-sized items fit before overflowing, re-measuring on container resize.
+ */
+export function useResponsiveToolbarItems(itemCount: number, gap: number) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const firstItemRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(itemCount);
+
+  const recalculate = useCallback(() => {
+    const container = containerRef.current;
+    const itemWidth = firstItemRef.current?.offsetWidth ?? 0;
+    if (!container || itemWidth === 0) {
+      return;
+    }
+    setVisibleCount(calculateVisibleItemCount(container.clientWidth, itemCount, itemWidth, gap));
+  }, [itemCount, gap]);
+
+  useLayoutEffect(() => {
+    recalculate();
+  }, [recalculate]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => recalculate());
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [recalculate]);
+
+  return {containerRef, firstItemRef, visibleCount};
+}


### PR DESCRIPTION
### 📓 Referenced Issue

Fixes #1368

### ℹ️ About the PR

The per-device toolbar (refresh, screenshot, design overlay, devtools, rotate, rulers, color-blindness tools, etc.) renders all of its action icons in a single row. On narrow, mobile-width device previews this row overflows and falls back to a horizontal scrollbar, which was flagged as a usability/visual issue in #1368.

This implements the direction discussed on the issue: keep as many icons visible inline as the available toolbar width allows, and collapse the rest into a "More Options" dropdown at the end, rather than wrapping to a second row (which was explicitly ruled out due to the resulting uneven alignment between devices previewed side-by-side).

### How

- `useResponsiveToolbarItems`: a small hook that measures the toolbar container and the first rendered icon's width, and recomputes (via `ResizeObserver`) how many icons fit before an overflow trigger would be needed. The core calculation is extracted as a pure `calculateVisibleItemCount` function.
- `OverflowMenu`: a lightweight popover (built with the same `@headlessui/react` `Popover` + `@headlessui-float/react` `Float` primitives already used elsewhere in the codebase, e.g. the existing `DropDown` component) that renders arbitrary overflowed toolbar items — this had to be a generic children-based popover rather than the existing label/options-based `DropDown`, since one of the toolbar items (`ColorBlindnessTools`) is itself a full dropdown component, not a simple action.
- `Toolbar/index.tsx`: the toolbar's action buttons are now built as an array and sliced into visible/overflow based on the hook's output. No behavioral changes to any individual action — only where each one renders.

No new dependencies were added.

### 🖼️ Testing Scenarios / Screenshots

- Added unit tests for `calculateVisibleItemCount` covering: everything fits, exact-fit boundary, partial overflow, the "reserve room for the overflow trigger" invariant, too-narrow-for-anything, and the initial-render/unmeasured fallback.
- Ran `yarn lint`, `yarn exec tsc`, `yarn test` (all passing) and `yarn build` (production build succeeds) locally.
- Manually verified in the running app across differently-sized device previews:
  - A narrow device (e.g. iPhone 12 Pro) now shows only as many icons as fit, plus a "⋮" overflow trigger — no more horizontal scrollbar.
  - A wide device (e.g. iPad) still shows all icons inline with no overflow trigger.
  - Opening the overflow dropdown shows the remaining icons, and each one still works (verified refresh, open devtools, and the nested color-blindness/vision-simulation dropdown all function correctly from inside the overflow panel).
  - Resizing the available toolbar width dynamically (e.g. opening/closing devtools panels) correctly recalculates how many icons are shown.

Happy to attach screenshots/a short recording here if it'd help review — just let me know.